### PR TITLE
Fix CEF renderer int3 without CrossOver's ntdll (WINE_SIMULATE_WRITECOPY=1)

### DIFF
--- a/docs/DIAGNOSIS.md
+++ b/docs/DIAGNOSIS.md
@@ -28,6 +28,38 @@ stock Whisky / frankea 엔진(v3.1.1, v4.5beta, v2.5.0)은 전부 **신형 WoW64
 - `--disable-gpu-compositing`로 실행 (소프트웨어 합성).
 - GL 에러(`SharedImageStub`, `Failed to create ... context for virtualization`)는 **무해** — 진짜 CrossOver도 동일하게 99개씩 냄.
 
+## 벽 1 — 진짜 원인 확정: `WINE_SIMULATE_WRITECOPY` (2026-08-29)
+
+위 "신형 WoW64" 설명은 결과적으로 맞는 엔진을 고르게 했지만 원인은 아니었다. CrossOver 26.3 GPL 소스로
+직접 빌드한 엔진(`cx26-engine`)에서도 같은 int3(`libcef.dll+0x16D00E1`)가 재현됐고, CX 출하 바이너리의
+`ntdll.so` 하나만 바꿔 끼우면 사라졌다. 동적 추적(`WINEDEBUG=+seh,+virtual,+process,+loaddll`)으로 특정한 내용:
+
+- 크래시 프로세스: `Battle.net.exe --type=renderer` (CEF 렌더러)의 초기 스레드, DLL 로드 직후.
+- 크래시 지점 디스어셈블(libcef RVA `0x16D00A0`):
+  ```
+  ret = VirtualProtect(addr, size, PAGE_READONLY /*2*/, &old);
+  if (!ret)   int3;          // 0x16D00DE
+  if (old != PAGE_READWRITE /*4*/) int3;   // 0x16D00E1  ← 여기서 죽음
+  ```
+- `addr`는 `libcef.dll`의 `.data` 페이지(이미지 매핑, write-copy). 순정 wine은 이미지의 쓰기 가능 페이지를
+  처음부터 RW로 mmap 하고 첫 쓰기를 추적하지 않으므로 `old`가 영원히 `PAGE_WRITECOPY(8)`이다.
+  Windows는 첫 쓰기 후 `PAGE_READWRITE(4)`로 바뀐다.
+- CX 소스에는 이를 흉내 내는 **CW Hack 22996** (`simulate_writecopy`, `dlls/ntdll/unix/virtual.c`
+  `NtProtectVirtualMemory`의 "Setting VPROT_COPIED")가 있지만, 공개 소스는 `WINE_SIMULATE_WRITECOPY` 환경변수로만
+  켜진다(`loader.c: hacks_init`). CX 출하 바이너리는 같은 환경에서 이 경로를 탄다 → 기본값이 다름.
+
+검증 (각 75~90초, 같은 보틀):
+
+| 엔진 | `EXCEPTION_BREAKPOINT` | 렌더러 생존 |
+|---|---|---|
+| cx26-engine (우리 빌드) | 2 | ✗ |
+| cx26-engine + SDK15 재빌드 ntdll | 2 | ✗ (툴체인 가설 기각) |
+| cx26-engine + CX ntdll.so | 0 | ✓ |
+| cx26-engine + `WINE_SIMULATE_WRITECOPY=1` | 0 | ✓ (90초 후 렌더러 2개 생존, 로그인·메인창 OK) |
+
+해결: 모든 실행 경로(`install.sh`, `scripts/play.sh`, `scripts/create-bottle.sh`)에 `WINE_SIMULATE_WRITECOPY=1`.
+CrossOver 바이너리 의존 0.
+
 ## 벽 2 — Battle.net Agent caller 서명 검증 실패 (해결됨)
 
 ### 증상

--- a/docs/DIAGNOSIS.md
+++ b/docs/DIAGNOSIS.md
@@ -60,6 +60,24 @@ stock Whisky / frankea 엔진(v3.1.1, v4.5beta, v2.5.0)은 전부 **신형 WoW64
 해결: 모든 실행 경로(`install.sh`, `scripts/play.sh`, `scripts/create-bottle.sh`)에 `WINE_SIMULATE_WRITECOPY=1`.
 CrossOver 바이너리 의존 0.
 
+## 벽 1-b — CX 의존 #2: 투명한 메인창 (`--in-process-gpu --use-gl=swiftshader`) (2026-08-29)
+
+`WINE_SIMULATE_WRITECOPY=1`만으로는 렌더러는 살지만 **Dock 아이콘만 뜨고 창이 안 보인다**. `CGWindowListCopyWindowInfo`로
+보면 1600×1000 창이 화면 정중앙에 "존재"(alpha 1)하지만 내용이 없다 — Battle.net 메인창은 frameless라 내용이 안 그려지면
+완전히 투명하다. libcef 로그 비교:
+
+- CX ntdll: GPU 프로세스 없음(NtCreateUserProcess `--type=gpu-process` 0건), 브라우저 프로세스 안에서 GLES 컨텍스트 생성.
+- 우리 ntdll: `--type=gpu-process`가 생성되고 `Exiting GPU process due to errors during initialization` ×9 →
+  `GL is disabled` → 아무것도 합성되지 않음.
+
+원인: A에서 Battle.net.exe가 받는 인자가 `--disable-gpu-compositing --from-launcher --in-process-gpu --use-gl=swiftshader`.
+`Battle.net Launcher.exe`는 양쪽 다 앞의 두 개만 넘기고(`+relay`로 확인), 뒤의 두 개는 **CX ntdll.so의 NtCreateUserProcess
+내부에서 주입**된다. 출처는 CodeWeavers의 비공개·암호화 호환 DB(`~/Library/Application Support/CrossOver/compatdb-26.dat`,
+`cxcompatdb.so`)의 앱별 규칙 — GPL 소스에도, 바이너리 문자열에도 없다.
+
+해결: Launcher.exe를 거치지 않고 `Battle.net.exe --disable-gpu-compositing --from-launcher --in-process-gpu --use-gl=swiftshader`를
+직접 실행 (`install.sh` 런처, `scripts/play.sh`). 검증: GPU 프로세스 0, GLES 컨텍스트 생성, 렌더러 6, 로그인·메인창, **화면 표시·게임 실행 사용자 확인**.
+
 ## 벽 2 — Battle.net Agent caller 서명 검증 실패 (해결됨)
 
 ### 증상

--- a/install.sh
+++ b/install.sh
@@ -82,7 +82,7 @@ EOT
 fi
 
 # ---------- 3. Bottle + Battle.net ----------
-export WINEPREFIX="$BOTTLE" WINEDEBUG=fixme-all WINEMSYNC=1 ROSETTA_ADVERTISE_AVX=1
+export WINEPREFIX="$BOTTLE" WINEDEBUG=fixme-all WINEMSYNC=1 ROSETTA_ADVERTISE_AVX=1 WINE_SIMULATE_WRITECOPY=1
 export CX_APPLEGPTK_LIBD3DSHARED_PATH="$ENGINE/lib/external/libd3dshared.dylib"
 export DYLD_FALLBACK_LIBRARY_PATH="$ENGINE/lib:/usr/lib"
 if [ -f "$BOTTLE/drive_c/Program Files (x86)/Battle.net/Battle.net.exe" ]; then
@@ -120,7 +120,7 @@ APP="$HOME/Applications/Battle.net.app"
 mkdir -p "$APP/Contents/MacOS"
 cat > "$APP/Contents/MacOS/launcher" <<EOF
 #!/bin/bash
-export WINEPREFIX="$BOTTLE" WINEDEBUG=fixme-all WINEMSYNC=1 ROSETTA_ADVERTISE_AVX=1
+export WINEPREFIX="$BOTTLE" WINEDEBUG=fixme-all WINEMSYNC=1 ROSETTA_ADVERTISE_AVX=1 WINE_SIMULATE_WRITECOPY=1
 export CX_APPLEGPTK_LIBD3DSHARED_PATH="$ENGINE/lib/external/libd3dshared.dylib"
 export DYLD_FALLBACK_LIBRARY_PATH="$ENGINE/lib:/usr/lib"
 BN="\$WINEPREFIX/drive_c/Program Files (x86)/Battle.net"

--- a/install.sh
+++ b/install.sh
@@ -127,7 +127,9 @@ BN="\$WINEPREFIX/drive_c/Program Files (x86)/Battle.net"
 for v in "\$BN"/Battle.net.[0-9]*; do [ -d "\$v" ] && cp -f "\$BN/Battle.net.exe" "\$v/Battle.net.exe" 2>/dev/null; done
 # Reap zombie game processes so quitting the game really quits it
 pgrep -f "soju-reaper.sh \$WINEPREFIX" >/dev/null 2>&1 || { [ -x "$REAPER" ] && ( "$REAPER" "\$WINEPREFIX" "$ENGINE/bin/wineserver" >/dev/null 2>&1 & ); }
-exec "$ENGINE/bin/wine" "C:\\\\Program Files (x86)\\\\Battle.net\\\\Battle.net Launcher.exe" --disable-gpu-compositing
+# Battle.net.exe directly (not Launcher.exe): CrossOver's private compat DB injects these two
+# switches; without them CEF's GPU process dies and the main window stays transparent.
+exec "$ENGINE/bin/wine" "C:\\\\Program Files (x86)\\\\Battle.net\\\\Battle.net.exe" --disable-gpu-compositing --from-launcher --in-process-gpu --use-gl=swiftshader
 EOF
 chmod +x "$APP/Contents/MacOS/launcher"
 cat > "$APP/Contents/Info.plist" <<'EOF'

--- a/research/writecopy-root-cause.txt
+++ b/research/writecopy-root-cause.txt
@@ -1,0 +1,28 @@
+=== CEF renderer int3 root cause (2026-08-29) ===
+crash thread (renderer initial thread), WINEDEBUG=+seh,+virtual,+loaddll,+process, cx26-engine (our ntdll):
+
+0394:trace:loaddll:build_module Loaded L"C:\\Program Files (x86)\\Battle.net\\Battle.net.17731\\libcef.dll" at 678C0000: native
+...
+0394:trace:virtual:NtProtectVirtualMemory 0xffffffffffffffff 0x710a9000 00001000 00000002
+0394:trace:virtual:get_vprot_range_size base 0x710a9000, size 0x1000, mask 0x20.
+0394:trace:virtual:dump_view View: 0x678c0000 - 0x71843fff c-rWx (image)
+0394:trace:virtual:dump_view       0x71089000 - 0x710a8fff c-rW-
+0394:trace:virtual:dump_view       0x710a9000 - 0x710a9fff c-r--
+0394:trace:seh:dispatch_exception code=80000003 (EXCEPTION_BREAKPOINT) flags=0 addr=68F900E1   (= libcef+0x16D00E1)
+wine: Unhandled exception 0x80000003 in thread 394 at address 68F900E1 (thread 0394), starting debugger...
+
+same call under CX-shipped ntdll.so (shadow-engine), same page (libcef @ 6C680000 -> 0x75e69000):
+03ec:trace:virtual:NtProtectVirtualMemory 0xffffffffffffffff 0x75e69000 00001000 00000002
+03ec:trace:virtual:get_vprot_range_size base 0x75e69000, size 0x1000, mask 0x20.
+03ec:trace:virtual:NtProtectVirtualMemory Setting VPROT_COPIED.      <-- simulate_writecopy path (CW Hack 22996)
+(no breakpoint)
+
+libcef.dll 0x116d00a0 (image base 0x10000000):
+  calll *0x197bc9e0        ; IAT -> KERNEL32.VirtualProtect(a, b, 2, &local)
+  testl %eax,%eax ; je 116d00de (int3)
+  cmpl $0x4,-0x8(%ebp) ; jne 116d00e1 (int3)   ; old protection must be PAGE_READWRITE
+
+crashing process cmdline: "Battle.net.exe --type=renderer ..." (parent NtCreateUserProcess pid 0390 tid 0394)
+
+fix verified: WINE_SIMULATE_WRITECOPY=1 with pristine cx26-engine -> 0 breakpoints, renderers alive at 90s,
+"Logged into Battle.net successfully" + "Attempting to show main window".

--- a/scripts/build-engine.sh
+++ b/scripts/build-engine.sh
@@ -85,7 +85,7 @@ echo "==> Done: $ENGINE"
 DYLD_FALLBACK_LIBRARY_PATH="$ENGINE/lib:/usr/lib" "$ENGINE/bin/wine" --version
 echo
 echo "Example launch:"
-echo "  export WINEPREFIX=<bottle> CX_GRAPHICS_BACKEND=d3dmetal WINEMSYNC=1"
+echo "  export WINEPREFIX=<bottle> CX_GRAPHICS_BACKEND=d3dmetal WINEMSYNC=1 WINE_SIMULATE_WRITECOPY=1"
 echo "  export DYLD_FALLBACK_LIBRARY_PATH='$ENGINE/lib:/usr/lib'"
 echo "  '$ENGINE/bin/wine' 'C:\\\\Program Files (x86)\\\\Battle.net\\\\Battle.net Launcher.exe' --disable-gpu-compositing"
 echo "  (Apple-protected binaries (nohup, ...) in the chain strip DYLD_* — background it with a subshell & instead)"

--- a/scripts/create-bottle.sh
+++ b/scripts/create-bottle.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 ENGINE="${ENGINE:-$HOME/.battlenet-macos/cx26-engine}"
 export WINEPREFIX="${WINEPREFIX:-$HOME/.battlenet-macos/bottle}"
 export WINEDEBUG="${WINEDEBUG:-fixme-all}"
-export WINEMSYNC=1 ROSETTA_ADVERTISE_AVX=1
+export WINEMSYNC=1 ROSETTA_ADVERTISE_AVX=1 WINE_SIMULATE_WRITECOPY=1
 export CX_APPLEGPTK_LIBD3DSHARED_PATH="$ENGINE/lib/external/libd3dshared.dylib"
 export DYLD_FALLBACK_LIBRARY_PATH="$ENGINE/lib:/usr/lib"
 

--- a/scripts/play.sh
+++ b/scripts/play.sh
@@ -27,6 +27,13 @@ fi
 export WINEDEBUG="${WINEDEBUG:-fixme-all}"
 export WINEMSYNC=1
 export ROSETTA_ADVERTISE_AVX=1
+# Battle.net's CEF renderer CHECKs that VirtualProtect() on a written .data page
+# of libcef.dll reports PAGE_READWRITE. Plain wine reports PAGE_WRITECOPY for
+# image pages forever (it maps them RW and never tracks the first write), so the
+# renderer hits int3 on startup and the login webview stays blank. CrossOver's
+# ntdll enables the "simulate writecopy" hack (CW Hack 22996) by default; the
+# GPL source only enables it through this env var. See docs/DIAGNOSIS.md.
+export WINE_SIMULATE_WRITECOPY=1
 export CX_ACTIVE_GRAPHICS_BACKEND=d3dmetal
 export CX_GRAPHICS_BACKEND=d3dmetal
 export CX_APPLEGPTK_LIBD3DSHARED_PATH="$ENGINE/lib/external/libd3dshared.dylib"

--- a/scripts/play.sh
+++ b/scripts/play.sh
@@ -57,10 +57,15 @@ start_reaper(){
 
 case "$MODE" in
   battlenet)   # Battle.net launcher (log in, then Play for online)
+    # Battle.net.exe is started directly, not through "Battle.net Launcher.exe":
+    # CrossOver's private compat DB (compatdb-*.dat) injects
+    # --in-process-gpu --use-gl=swiftshader for Battle.net.exe. Without them CEF
+    # spawns a separate GPU process that dies on init and the frameless main
+    # window stays fully transparent (Dock icon, no window). See docs/DIAGNOSIS.md.
     start_reaper
     exec "$ENGINE/bin/wine" \
-      "C:\\Program Files (x86)\\Battle.net\\Battle.net Launcher.exe" \
-      --disable-gpu-compositing
+      "C:\\Program Files (x86)\\Battle.net\\Battle.net.exe" \
+      --disable-gpu-compositing --from-launcher --in-process-gpu --use-gl=swiftshader
     ;;
   d2r)         # Launch the game directly (offline / previous session)
     start_reaper


### PR DESCRIPTION
## Root cause
Battle.net's CEF renderer (`Battle.net.exe --type=renderer`) dies on startup with int3 at `libcef.dll+0x16D00E1`:

```
ret = VirtualProtect(addr, size, PAGE_READONLY, &old);
CHECK(ret); CHECK(old == PAGE_READWRITE);   // <- fails
```

`addr` is a libcef `.data` page (image mapping, write-copy). Plain wine maps those pages RW up front and never tracks the first write, so `old` stays `PAGE_WRITECOPY`. CrossOver's shipped `ntdll.so` takes the `simulate_writecopy` path (CW Hack 22996, "Setting VPROT_COPIED") by default; the GPL source only enables it via `WINE_SIMULATE_WRITECOPY`.

## Fix
Export `WINE_SIMULATE_WRITECOPY=1` in `install.sh`, `scripts/play.sh`, `scripts/create-bottle.sh` (+ hint in `build-engine.sh`). No CrossOver binary needed anymore.

## Verification (same bottle, 75–90 s runs, `WINEDEBUG=+seh`)
| engine | EXCEPTION_BREAKPOINT | renderer alive |
|---|---|---|
| cx26-engine | 2 | ✗ |
| cx26-engine + macOS 15 SDK rebuilt ntdll | 2 | ✗ |
| cx26-engine + CX ntdll.so | 0 | ✓ |
| cx26-engine + `WINE_SIMULATE_WRITECOPY=1` | 0 | ✓ (2 renderers alive at 90 s, login + main window) |

Trace excerpts in `research/writecopy-root-cause.txt`, write-up in `docs/DIAGNOSIS.md`.

https://claude.ai/code/session_01TiFcqQceFHoQLeJXf63twY

## Update: second CrossOver dependency
With only `WINE_SIMULATE_WRITECOPY=1` the renderer survives but the main window is transparent (Dock icon, no window). CrossOver's private compat DB (`compatdb-26.dat` via `cxcompatdb.so`) injects `--in-process-gpu --use-gl=swiftshader` into Battle.net.exe's command line inside NtCreateUserProcess; without them CEF's separate GPU process dies on init and nothing is composited. Fix: launch `Battle.net.exe` directly with those switches instead of going through `Battle.net Launcher.exe` (install.sh launcher, play.sh). Verified on the pristine engine: window visible, login, game runs.