### PR TITLE
Steam: Windows-like tray UX (Dock click reopens) + reaper cleanup after Exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ D2R shipped on Steam in Feb 2026 as the *Infernal Edition*. Steam support uses a
 ```bash
 scripts/create-steam-bottle.sh   # installs wine-stable + wrapper + official Valve installer
 scripts/play.sh steam            # log in -> install & play
-scripts/play.sh steam-kill       # stop the Steam bottle
+scripts/play.sh steam-kill       # stop the Steam bottle (closing the Steam window also shuts it down after ~40 s)
 ```
 
 Verified on M4 Pro / macOS 26.5: login, library, and an actual D3D11 (Unity) game rendering in-game via a DXMT fork — see `docs/STEAM-GAMES.md` for the full wiring (`scripts/setup-steam-games.sh`). Notes: switch your macOS input source to English (ABC) when typing in Steam (IME composition shows as `?` otherwise).

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ D2R shipped on Steam in Feb 2026 as the *Infernal Edition*. Steam support uses a
 ```bash
 scripts/create-steam-bottle.sh   # installs wine-stable + wrapper + official Valve installer
 scripts/play.sh steam            # log in -> install & play
-scripts/play.sh steam-kill       # stop the Steam bottle (closing the Steam window also shuts it down after ~40 s)
+scripts/play.sh steam-kill       # stop the Steam bottle (closing the window keeps Steam running; click the Dock icon to bring it back, Steam > Exit quits)
 ```
 
 Verified on M4 Pro / macOS 26.5: login, library, and an actual D3D11 (Unity) game rendering in-game via a DXMT fork — see `docs/STEAM-GAMES.md` for the full wiring (`scripts/setup-steam-games.sh`). Notes: switch your macOS input source to English (ABC) when typing in Steam (IME composition shows as `?` otherwise).

--- a/docs/STEAM-GAMES.md
+++ b/docs/STEAM-GAMES.md
@@ -71,7 +71,10 @@ three fixes we needed on macOS 26.5 / current Homebrew:
 
 DXMT is LGPL-2.1+ (Copyright Feifan He for CodeWeavers); the wrapper is MIT
 (vendored in `third_party/`); our winemac patch is published as
-`patches/winemac-no-dock-icon.patch` (LGPL-2.1+, matching Wine). Nothing
+`patches/winemac-no-dock-icon.patch` (LGPL-2.1+, matching Wine). The same patch adds
+`WINE_DOCK_REOPEN_CMD`: when the Dock icon is clicked and no Wine window is visible, winemac runs
+the command — `play.sh steam` sets it to `steam.exe steam://open/main`, so closing the Steam window
+parks it (as on Windows) and a Dock click brings it back; Steam > Exit really quits. Nothing
 proprietary is redistributed.
 
 Artifacts land in `~/.battlenet-macos/steam-support/` and

--- a/patches/winemac-no-dock-icon.patch
+++ b/patches/winemac-no-dock-icon.patch
@@ -1,5 +1,5 @@
 diff --git a/dlls/winemac.drv/cocoa_app.m b/dlls/winemac.drv/cocoa_app.m
-index 2a9dab2..63e871b 100644
+index 2a9dab2..7d41ce8 100644
 --- a/dlls/winemac.drv/cocoa_app.m
 +++ b/dlls/winemac.drv/cocoa_app.m
 @@ -230,6 +230,34 @@ - (void) transformProcessToForeground:(BOOL)activateIfTransformed
@@ -37,3 +37,38 @@ index 2a9dab2..63e871b 100644
              [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
  
              if (activateIfTransformed)
+@@ -2232,6 +2260,34 @@ - (BOOL) applicationShouldHandleReopen:(NSApplication*)theApplication hasVisible
+         // Note that "flag" is often wrong.  WineWindows are NSPanels and NSPanels
+         // don't count as "visible windows" for this purpose.
+         [self unminimizeWindowIfNoneVisible];
++
++        /* Soju: WINE_DOCK_REOPEN_CMD — Windows apps that "close to the tray"
++           (Steam) hide their window; there is no tray on macOS, so a Dock click
++           would do nothing. If nothing is visible after the unminimize attempt,
++           run the command (e.g. "steam.exe steam://open/main") to bring it back. */
++        {
++            const char* cmd = getenv("WINE_DOCK_REOPEN_CMD");
++            if (cmd && *cmd)
++            {
++                BOOL anyVisible = NO;
++                for (NSWindow* w in [NSApp windows])
++                {
++                    if ([w isKindOfClass:[WineWindow class]] && [w isVisible] && ![w isMiniaturized])
++                    {
++                        anyVisible = YES;
++                        break;
++                    }
++                }
++                if (!anyVisible)
++                {
++                    NSTask* task = [[NSTask alloc] init];
++                    task.launchPath = @"/bin/sh";
++                    task.arguments = @[@"-c", [NSString stringWithUTF8String:cmd]];
++                    @try { [task launch]; } @catch (NSException* e) { NSLog(@"WINE_DOCK_REOPEN_CMD failed: %@", e); }
++                    [task release];
++                }
++            }
++        }
+         return YES;
+     }
+ 

--- a/scripts/play.sh
+++ b/scripts/play.sh
@@ -79,6 +79,7 @@ case "$MODE" in
     # -cef-single-process. Source: github.com/notpop/steam-on-m1-wine (MIT),
     # vendored in third_party/.
     WINESTABLE="/Applications/Wine Stable.app/Contents/Resources/wine/bin/wine"
+    WINESTABLE_SERVER="/Applications/Wine Stable.app/Contents/Resources/wine/bin/wineserver"
     [[ -x "$WINESTABLE" ]] || { echo "wine-stable not found — brew install --cask wine-stable"; exit 1; }
     ST="$WINEPREFIX/drive_c/Program Files (x86)/Steam/steam.exe"
     [[ -f "$ST" ]] || { echo "Steam not found — run scripts/create-steam-bottle.sh first"; exit 1; }
@@ -119,6 +120,10 @@ case "$MODE" in
     # 5) Launch — plain wine-stable environment, without the CX engine env
     STEAM_CMD=("C:\\Program Files (x86)\\Steam\\steam.exe" -no-cef-sandbox -cef-single-process -noverifyfiles "${@:2}")
     [[ -n "$VD" ]] && STEAM_CMD=(explorer.exe "/desktop=soju-steam,$VD" "${STEAM_CMD[@]}")
+    # Reaper in steam mode: closing the Steam window normally leaves steam.exe
+    # parked in an invisible tray (Dock icon stays). Shut the bottle down instead.
+    pgrep -f "soju-reaper.sh $WINEPREFIX" >/dev/null 2>&1 || \
+      { [ -x "$REAPER" ] && ( "$REAPER" "$WINEPREFIX" "$WINESTABLE_SERVER" steam >/dev/null 2>&1 & ); }
     env -u DYLD_FALLBACK_LIBRARY_PATH -u CX_ACTIVE_GRAPHICS_BACKEND -u CX_GRAPHICS_BACKEND \
         -u CX_APPLEGPTK_LIBD3DSHARED_PATH -u WINEMSYNC -u ROSETTA_ADVERTISE_AVX \
       WINEPREFIX="$WINEPREFIX" WINEDEBUG="${WINEDEBUG:-fixme-all}" \
@@ -134,6 +139,7 @@ case "$MODE" in
     # wine-stable, so it needs wine-stable's wineserver. Killing the CX engine's
     # wineserver here does nothing and leaves steam.exe alive, which then keeps
     # respawning steamwebhelper (it looks like "Steam relaunches itself").
+    pkill -f "soju-reaper.sh $WINEPREFIX" 2>/dev/null || true
     "/Applications/Wine Stable.app/Contents/Resources/wine/bin/wineserver" -k 2>/dev/null || true
     ;;
   *) echo "usage: play.sh [battlenet|d2r|steam|kill|steam-kill]"; exit 1;;

--- a/scripts/play.sh
+++ b/scripts/play.sh
@@ -120,8 +120,12 @@ case "$MODE" in
     # 5) Launch — plain wine-stable environment, without the CX engine env
     STEAM_CMD=("C:\\Program Files (x86)\\Steam\\steam.exe" -no-cef-sandbox -cef-single-process -noverifyfiles "${@:2}")
     [[ -n "$VD" ]] && STEAM_CMD=(explorer.exe "/desktop=soju-steam,$VD" "${STEAM_CMD[@]}")
-    # Reaper in steam mode: closing the Steam window normally leaves steam.exe
-    # parked in an invisible tray (Dock icon stays). Shut the bottle down instead.
+    # Closing the Steam window parks it in a tray macOS does not show; the patched
+    # winemac runs WINE_DOCK_REOPEN_CMD on a Dock-icon click when no window is
+    # visible, which makes the running Steam show its window again (same UX as
+    # Windows' tray icon).
+    # Reaper in steam mode: once Steam itself exits (Steam menu > Exit), tear the
+    # rest of the bottle down so no Dock icon / winedevice lingers.
     pgrep -f "soju-reaper.sh $WINEPREFIX" >/dev/null 2>&1 || \
       { [ -x "$REAPER" ] && ( "$REAPER" "$WINEPREFIX" "$WINESTABLE_SERVER" steam >/dev/null 2>&1 & ); }
     env -u DYLD_FALLBACK_LIBRARY_PATH -u CX_ACTIVE_GRAPHICS_BACKEND -u CX_GRAPHICS_BACKEND \
@@ -129,6 +133,7 @@ case "$MODE" in
       WINEPREFIX="$WINEPREFIX" WINEDEBUG="${WINEDEBUG:-fixme-all}" \
       WINEDLLOVERRIDES="bcrypt=b;ncrypt=b;gameoverlayrenderer,gameoverlayrenderer64=d" \
       WINE_NO_DOCK_ICON="steam.exe;steamservice.exe" \
+      WINE_DOCK_REOPEN_CMD="'$WINESTABLE' 'C:\\Program Files (x86)\\Steam\\steam.exe' steam://open/main" \
       "$WINESTABLE" "${STEAM_CMD[@]}"
     ;;
   kill)        # Stop everything in the Battle.net bottle

--- a/scripts/soju-reaper.sh
+++ b/scripts/soju-reaper.sh
@@ -11,14 +11,29 @@
 # Window detection uses CGWindowListCopyWindowInfo via python3+ctypes — no
 # Accessibility permission needed, nothing to install.
 #
-# Usage: soju-reaper.sh <WINEPREFIX> <wineserver-path>   (backgrounded by play.sh)
+# Usage: soju-reaper.sh <WINEPREFIX> <wineserver-path> [battlenet|steam]
+#        (backgrounded by play.sh / the Battle.net.app launcher)
+#
+# steam mode: the Windows Steam client never really quits — closing its window
+# just parks it in a tray that macOS does not show, so the Dock icon and half a
+# dozen processes linger. In steam mode "no Steam/game window on screen for two
+# checks" means the user is done: the whole Steam bottle is shut down.
 set -u
 
-PREFIX="${1:?usage: soju-reaper.sh <WINEPREFIX> <wineserver>}"
+PREFIX="${1:?usage: soju-reaper.sh <WINEPREFIX> <wineserver> [battlenet|steam]}"
 WINESERVER="${2:?}"
+MODE="${3:-battlenet}"
 INTERVAL=20
-GAME_RE='D2R\.exe|BlizzardError\.exe'
-UI_RE='Battle\.net\.exe.*--from-launcher|Battle\.net Launcher\.exe'
+case "$MODE" in
+  steam)
+    GAME_RE='Steam\\steamapps\\'                      # games live under steamapps
+    UI_RE='steam\.exe|steamwebhelper'
+    ;;
+  *)
+    GAME_RE='D2R\.exe|BlizzardError\.exe'
+    UI_RE='Battle\.net\.exe.*--from-launcher|Battle\.net Launcher\.exe'
+    ;;
+esac
 
 window_pids() {
   /usr/bin/python3 - <<'PY'
@@ -52,6 +67,29 @@ PY
 
 declare -A STRIKES
 IDLE_STRIKES=0
+
+if [ "$MODE" = "steam" ]; then
+  # Wait for Steam to show a window first (login/update can take a while), then
+  # tear the bottle down once neither Steam nor a game has a window for 40s.
+  SEEN=0; NOWIN=0
+  while true; do
+    sleep "$INTERVAL"
+    PIDS=$(pgrep -f "$UI_RE|$GAME_RE" 2>/dev/null || true)
+    [ -z "$PIDS" ] && { [ "$SEEN" = 1 ] && exit 0; continue; }
+    WINS=" $(window_pids) "
+    HAS=0
+    for pid in $PIDS; do [[ "$WINS" == *" $pid "* ]] && { HAS=1; break; }; done
+    if [ "$HAS" = 1 ]; then SEEN=1; NOWIN=0; continue; fi
+    [ "$SEEN" = 1 ] || continue
+    NOWIN=$((NOWIN + 1))
+    if [ "$NOWIN" -ge 2 ]; then
+      WINEPREFIX="$PREFIX" "$WINESERVER" -k 2>/dev/null || true
+      sleep 3
+      pkill -9 -f "$UI_RE|steamservice\.exe" 2>/dev/null || true
+      exit 0
+    fi
+  done
+fi
 
 while true; do
   sleep "$INTERVAL"

--- a/scripts/soju-reaper.sh
+++ b/scripts/soju-reaper.sh
@@ -14,10 +14,9 @@
 # Usage: soju-reaper.sh <WINEPREFIX> <wineserver-path> [battlenet|steam]
 #        (backgrounded by play.sh / the Battle.net.app launcher)
 #
-# steam mode: the Windows Steam client never really quits — closing its window
-# just parks it in a tray that macOS does not show, so the Dock icon and half a
-# dozen processes linger. In steam mode "no Steam/game window on screen for two
-# checks" means the user is done: the whole Steam bottle is shut down.
+# steam mode: closing the Steam window parks it in a tray (as on Windows; the
+# Dock icon brings it back via WINE_DOCK_REOPEN_CMD). Once steam.exe itself has
+# exited, the leftovers (steamservice, winedevice, wineserver) are shut down.
 set -u
 
 PREFIX="${1:?usage: soju-reaper.sh <WINEPREFIX> <wineserver> [battlenet|steam]}"
@@ -69,24 +68,21 @@ declare -A STRIKES
 IDLE_STRIKES=0
 
 if [ "$MODE" = "steam" ]; then
-  # Wait for Steam to show a window first (login/update can take a while), then
-  # tear the bottle down once neither Steam nor a game has a window for 40s.
-  SEEN=0; NOWIN=0
+  # Steam parks itself in an (invisible on macOS) tray when its window is closed,
+  # so a missing window means nothing here. Only once steam.exe has really gone
+  # (Steam menu > Exit) do we shut the rest of the bottle down.
   while true; do
     sleep "$INTERVAL"
-    PIDS=$(pgrep -f "$UI_RE|$GAME_RE" 2>/dev/null || true)
-    [ -z "$PIDS" ] && { [ "$SEEN" = 1 ] && exit 0; continue; }
-    WINS=" $(window_pids) "
-    HAS=0
-    for pid in $PIDS; do [[ "$WINS" == *" $pid "* ]] && { HAS=1; break; }; done
-    if [ "$HAS" = 1 ]; then SEEN=1; NOWIN=0; continue; fi
-    [ "$SEEN" = 1 ] || continue
-    NOWIN=$((NOWIN + 1))
-    if [ "$NOWIN" -ge 2 ]; then
-      WINEPREFIX="$PREFIX" "$WINESERVER" -k 2>/dev/null || true
-      sleep 3
-      pkill -9 -f "$UI_RE|steamservice\.exe" 2>/dev/null || true
-      exit 0
+    if ! pgrep -f 'steam\.exe' >/dev/null 2>&1; then
+      IDLE_STRIKES=$((IDLE_STRIKES + 1))
+      if [ "$IDLE_STRIKES" -ge 2 ]; then
+        WINEPREFIX="$PREFIX" "$WINESERVER" -k 2>/dev/null || true
+        sleep 3
+        pkill -9 -f "$UI_RE|steamservice\.exe" 2>/dev/null || true
+        exit 0
+      fi
+    else
+      IDLE_STRIKES=0
     fi
   done
 fi


### PR DESCRIPTION
Closing the Steam window parks it in a tray macOS cannot show, so the Dock icon and processes used to linger with no way back.

- **winemac patch** (`patches/winemac-no-dock-icon.patch`, LGPL): new `WINE_DOCK_REOPEN_CMD` — on a Dock-icon click with no visible Wine window, winemac runs the command. `play.sh steam` sets it to `steam.exe steam://open/main`, which makes the running Steam show its window again → same UX as the Windows tray icon.
- **soju-reaper steam mode**: started by `play.sh steam`; tears the bottle down (wineserver, steamservice, winedevice) only after steam.exe itself has exited (Steam > Exit). `steam-kill` also stops the reaper.
- README / docs/STEAM-GAMES.md notes.

Rebuilt `winemac-patched.so` goes into `~/.battlenet-macos/steam-support/` (setup-steam-games.sh copies it into the wine-stable bundle).

Verified: close window → Dock click → window back in ~1 s (user confirmed); Exit → bottle gone.

https://claude.ai/code/session_01TiFcqQceFHoQLeJXf63twY