### PR TITLE
Epic Games Launcher support + fix engine lookup in install.sh

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -2,7 +2,7 @@
 
 > *Wine → Whisky → Kegworks… 그리고 한국의 차례: **Soju** 🍶*
 
-**Apple Silicon 맥에서 Battle.net과 디아블로 II: 레저렉션을 — 완전 무료 오픈소스 Wine 스택으로.**
+**Apple Silicon 맥에서 Battle.net·디아블로 II: 레저렉션·Epic Games Launcher·Steam을 — 완전 무료 오픈소스 Wine 스택으로.**
 
 CodeWeavers가 GPL로 공개한 소스(Wine 11.0, CrossOver 26.3 소스 드롭)를 이 레포의 스크립트로 직접 빌드·조립합니다. 유료 소프트웨어 불필요.
 
@@ -66,6 +66,18 @@ scripts/play.sh kill        # 전부 종료
 ```
 
 이미 CrossOver 보틀에 게임이 설치돼 있다면 `scripts/setup-bottle.sh`로 복제하세요 (28GB 재다운로드 회피).
+
+## Epic Games Launcher
+
+같은 엔진, 별도 보틀, 추가 트릭 없음: Epic의 CEF는 이 빌드에서 GPU 프로세스가 죽지 않아 런처가 기본 커맨드라인 그대로 뜹니다. 검증 2026-08-29: 공식 MSI 무인 설치(~30초), 런처 UI, 로그인.
+
+```bash
+scripts/create-epic-bottle.sh    # 공식 Epic MSI, 무인 설치
+scripts/play.sh epic             # 로그인 → 게임 설치·플레이
+scripts/play.sh epic-kill        # Epic 보틀 종료 (창을 닫아도 런처는 살아 있고, Dock 아이콘 클릭으로 복귀, Exit로 종료)
+```
+
+게임은 아직 폭넓게 테스트하지 않았습니다. 커널 안티치트(EAC/BattlEye)가 필요한 게임은 Wine에서 돌지 않습니다.
 
 ## Steam 지원 (Steam판 D2R 포함)
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -74,7 +74,7 @@ scripts/play.sh kill        # 전부 종료
 ```bash
 scripts/create-epic-bottle.sh    # 공식 Epic MSI, 무인 설치
 scripts/play.sh epic             # 로그인 → 게임 설치·플레이
-scripts/play.sh epic-kill        # Epic 보틀 종료 (창을 닫아도 런처는 살아 있음 — macOS 메뉴바의 Epic 아이콘에서 열기/Exit, Windows 트레이와 동일)
+scripts/play.sh epic-kill        # Epic 보틀 종료 (창을 닫아도 런처는 살아 있음 — macOS 메뉴바의 Epic 아이콘을 **우클릭**해 열기/Exit, Windows 트레이와 동일 — 좌클릭 한 번엔 반응 없음)
 ```
 
 게임은 아직 폭넓게 테스트하지 않았습니다. 커널 안티치트(EAC/BattlEye)가 필요한 게임은 Wine에서 돌지 않습니다.

--- a/README.ko.md
+++ b/README.ko.md
@@ -74,7 +74,7 @@ scripts/play.sh kill        # 전부 종료
 ```bash
 scripts/create-epic-bottle.sh    # 공식 Epic MSI, 무인 설치
 scripts/play.sh epic             # 로그인 → 게임 설치·플레이
-scripts/play.sh epic-kill        # Epic 보틀 종료 (창을 닫아도 런처는 살아 있고, Dock 아이콘 클릭으로 복귀, Exit로 종료)
+scripts/play.sh epic-kill        # Epic 보틀 종료 (창을 닫아도 런처는 살아 있음 — macOS 메뉴바의 Epic 아이콘에서 열기/Exit, Windows 트레이와 동일)
 ```
 
 게임은 아직 폭넓게 테스트하지 않았습니다. 커널 안티치트(EAC/BattlEye)가 필요한 게임은 Wine에서 돌지 않습니다.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Same engine, own bottle, no extra tricks: Epic's CEF keeps its GPU process alive
 ```bash
 scripts/create-epic-bottle.sh    # official Epic MSI, unattended
 scripts/play.sh epic             # log in -> install & play
-scripts/play.sh epic-kill        # stop the Epic bottle (closing the window keeps the launcher running; use the Epic icon in the macOS menu bar to reopen or Exit — same as the Windows tray)
+scripts/play.sh epic-kill        # stop the Epic bottle (closing the window keeps the launcher running; right-click the Epic icon in the macOS menu bar to reopen or Exit — same as the Windows tray; a plain left click does nothing, as Epic only reacts to the menu)
 ```
 
 Games have not been broadly tested yet; anything that needs kernel anti-cheat (EAC/BattlEye) will not run under Wine.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Same engine, own bottle, no extra tricks: Epic's CEF keeps its GPU process alive
 ```bash
 scripts/create-epic-bottle.sh    # official Epic MSI, unattended
 scripts/play.sh epic             # log in -> install & play
-scripts/play.sh epic-kill        # stop the Epic bottle (closing the window keeps the launcher running; click the Dock icon to bring it back, Exit quits)
+scripts/play.sh epic-kill        # stop the Epic bottle (closing the window keeps the launcher running; use the Epic icon in the macOS menu bar to reopen or Exit — same as the Windows tray)
 ```
 
 Games have not been broadly tested yet; anything that needs kernel anti-cheat (EAC/BattlEye) will not run under Wine.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 > *Wine → Whisky → Kegworks… and now a Korean round: **Soju** 🍶*
 
-**Run Battle.net and Diablo II: Resurrected on Apple Silicon Macs — with a fully free, open-source Wine stack.**
+**Run Battle.net, Diablo II: Resurrected, the Epic Games Launcher and Steam on Apple Silicon Macs — with a fully free, open-source Wine stack.**
 
 Built from CodeWeavers' published GPL sources (Wine 11.0, CrossOver 26.3 source drop), compiled and assembled by scripts in this repo. No paid software required.
 
-> Status (2026-08): **Working end-to-end** — Battle.net login, Agent, and D2R in-game rendering (D3DMetal), verified on an M4 Pro running macOS 26.5.
+> Status (2026-08): **Working end-to-end** — Battle.net login, Agent, and D2R in-game rendering (D3DMetal); Epic Games Launcher login; Steam client + D3D11 games. Verified on an M4 Pro running macOS 26.5.
 
 *[한국어 README](README.ko.md)*
 
@@ -36,7 +36,7 @@ Or via Homebrew:
 
 ```bash
 brew install BCD1210/soju/soju
-soju install     # then: soju battlenet / soju d2r / soju steam
+soju install     # then: soju battlenet / soju d2r / soju epic / soju steam
 ```
 
 Downloads the prebuilt engine (~350 MB), walks you through Apple's free GPTK download (the one file Apple forbids redistributing), auto-installs Battle.net with Blizzard's official installer, and drops a `Battle.net.app` in `~/Applications`. Log in and play.
@@ -70,6 +70,18 @@ scripts/play.sh kill        # stop everything
 ```
 
 Already have a CrossOver bottle with games installed? `scripts/setup-bottle.sh` clones it (28 GB game re-download avoided).
+
+## Epic Games Launcher
+
+Same engine, own bottle, no extra tricks: Epic's CEF keeps its GPU process alive on this build, so the launcher runs with its stock command line. Verified 2026-08-29: unattended install from the official MSI (~30 s), launcher UI, login.
+
+```bash
+scripts/create-epic-bottle.sh    # official Epic MSI, unattended
+scripts/play.sh epic             # log in -> install & play
+scripts/play.sh epic-kill        # stop the Epic bottle (closing the window keeps the launcher running; click the Dock icon to bring it back, Exit quits)
+```
+
+Games have not been broadly tested yet; anything that needs kernel anti-cheat (EAC/BattlEye) will not run under Wine.
 
 ## Steam (including the Steam version of D2R)
 

--- a/docs/DIAGNOSIS.md
+++ b/docs/DIAGNOSIS.md
@@ -78,6 +78,18 @@ CrossOver 바이너리 의존 0.
 해결: Launcher.exe를 거치지 않고 `Battle.net.exe --disable-gpu-compositing --from-launcher --in-process-gpu --use-gl=swiftshader`를
 직접 실행 (`install.sh` 런처, `scripts/play.sh`). 검증: GPU 프로세스 0, GLES 컨텍스트 생성, 렌더러 6, 로그인·메인창, **화면 표시·게임 실행 사용자 확인**.
 
+## Epic Games Launcher — 같은 엔진에서 추가 조치 없이 동작 (2026-08-29)
+
+벽 1/1-b가 배틀넷 고유 문제인지 CEF 일반 문제인지 확인하려고 Epic Games Launcher(UE5 + CEF3 `EpicWebHelper.exe`, Chrome/90)를 같은 엔진·같은 env(`WINE_SIMULATE_WRITECOPY=1` 포함)로 돌렸다.
+
+- 설치: 공식 `EpicGamesLauncherInstaller.msi`를 `msiexec /i … /qn`으로 무인 설치, 26초. 메뉴빌더 에러(`cx_wineshelllink`)만 나고 무해.
+- 실행: `EpicGamesLauncher.exe` 기본 인자 그대로. CEF가 `--type=gpu-process`를 별도 프로세스로 띄우는데 **죽지 않는다** — 배틀넷과 달리 `--in-process-gpu --use-gl=swiftshader`가 필요 없었다. 1826×857 메인창, 로그인, 스토어 UI 렌더링 확인.
+- wined3d는 `Using the Vulkan renderer for d3d10/11`(MoltenVK) 경로를 탔다. 런처 UI 자체는 이걸로 충분.
+- 로그의 `LogDPoP: Failed to create persistent DPoP key (0x80090029)`는 Linux Wine에서도 나오는 것으로 로그인에 영향 없음.
+- 트레이 UX: 창 닫기 = 트레이 상주(Windows와 동일). Dock 클릭 복귀는 `WINE_DOCK_REOPEN_CMD`로 exe를 다시 실행(싱글 인스턴스라 기존 창만 올라옴). 이를 위해 winemac 패치를 CX 엔진 빌드에도 적용(`build-engine.sh`가 `patches/winemac-no-dock-icon.patch`를 적용).
+
+결론: 벽 1(`WRITECOPY`)은 libcef 버전에 따라 걸리는 일반 문제일 수 있지만, 벽 1-b(GPU 프로세스 사망)는 Battle.net의 CEF 빌드/설정 고유. 다른 CEF 런처(GOG Galaxy·EA app·Ubisoft Connect)도 같은 절차로 먼저 "그냥 돌려보는" 것이 맞다.
+
 ## 벽 2 — Battle.net Agent caller 서명 검증 실패 (해결됨)
 
 ### 증상

--- a/docs/DIAGNOSIS.md
+++ b/docs/DIAGNOSIS.md
@@ -86,7 +86,8 @@ CrossOver 바이너리 의존 0.
 - 실행: `EpicGamesLauncher.exe` 기본 인자 그대로. CEF가 `--type=gpu-process`를 별도 프로세스로 띄우는데 **죽지 않는다** — 배틀넷과 달리 `--in-process-gpu --use-gl=swiftshader`가 필요 없었다. 1826×857 메인창, 로그인, 스토어 UI 렌더링 확인.
 - wined3d는 `Using the Vulkan renderer for d3d10/11`(MoltenVK) 경로를 탔다. 런처 UI 자체는 이걸로 충분.
 - 로그의 `LogDPoP: Failed to create persistent DPoP key (0x80090029)`는 Linux Wine에서도 나오는 것으로 로그인에 영향 없음.
-- 트레이 UX: 창 닫기 = 트레이 상주(Windows와 동일). Dock 클릭 복귀는 `WINE_DOCK_REOPEN_CMD`로 exe를 다시 실행(싱글 인스턴스라 기존 창만 올라옴). 이를 위해 winemac 패치를 CX 엔진 빌드에도 적용(`build-engine.sh`가 `patches/winemac-no-dock-icon.patch`를 적용).
+- 트레이 UX: 창 닫기 = 숨김(Windows와 동일). Epic이 `Shell_NotifyIcon`으로 등록한 트레이 아이콘을 winemac systray가 **macOS 메뉴바 NSStatusItem**으로 올리고(`+systray` 트레이스로 확인), 그 메뉴로 창 열기·Exit가 된다 — 사용자 검증 완료. 시도했다 버린 것들: exe 재실행·`com.epicgames.launcher://` URL은 실행 중 인스턴스가 무시; 외부에서 `ShowWindow(SW_SHOW/RESTORE)`로 숨긴 창을 띄우면 보이긴 하지만 Slate가 "최소화" 상태를 유지해 **입력을 안 받는 먹통 창**이 된다. 그래서 Epic 모드는 `WINE_DOCK_REOPEN_CMD`를 쓰지 않는다.
+- 부수 수정: `WINE_DOCK_REOPEN_CMD` 훅의 "보이는 창" 판정이 Epic의 화면 밖(-10000,-10000) 1×1 투명 보조창을 보이는 창으로 세던 것을 실제 화면 안·alpha>0·크기>1 조건으로 고쳤고, `build-engine.sh`가 CX 엔진에도 winemac 패치를 적용한다.
 
 결론: 벽 1(`WRITECOPY`)은 libcef 버전에 따라 걸리는 일반 문제일 수 있지만, 벽 1-b(GPU 프로세스 사망)는 Battle.net의 CEF 빌드/설정 고유. 다른 CEF 런처(GOG Galaxy·EA app·Ubisoft Connect)도 같은 절차로 먼저 "그냥 돌려보는" 것이 맞다.
 

--- a/docs/DIAGNOSIS.md
+++ b/docs/DIAGNOSIS.md
@@ -86,7 +86,7 @@ CrossOver 바이너리 의존 0.
 - 실행: `EpicGamesLauncher.exe` 기본 인자 그대로. CEF가 `--type=gpu-process`를 별도 프로세스로 띄우는데 **죽지 않는다** — 배틀넷과 달리 `--in-process-gpu --use-gl=swiftshader`가 필요 없었다. 1826×857 메인창, 로그인, 스토어 UI 렌더링 확인.
 - wined3d는 `Using the Vulkan renderer for d3d10/11`(MoltenVK) 경로를 탔다. 런처 UI 자체는 이걸로 충분.
 - 로그의 `LogDPoP: Failed to create persistent DPoP key (0x80090029)`는 Linux Wine에서도 나오는 것으로 로그인에 영향 없음.
-- 트레이 UX: 창 닫기 = 숨김(Windows와 동일). Epic이 `Shell_NotifyIcon`으로 등록한 트레이 아이콘을 winemac systray가 **macOS 메뉴바 NSStatusItem**으로 올리고(`+systray` 트레이스로 확인), 그 메뉴로 창 열기·Exit가 된다 — 사용자 검증 완료. 시도했다 버린 것들: exe 재실행·`com.epicgames.launcher://` URL은 실행 중 인스턴스가 무시; 외부에서 `ShowWindow(SW_SHOW/RESTORE)`로 숨긴 창을 띄우면 보이긴 하지만 Slate가 "최소화" 상태를 유지해 **입력을 안 받는 먹통 창**이 된다. 그래서 Epic 모드는 `WINE_DOCK_REOPEN_CMD`를 쓰지 않는다.
+- 트레이 UX: 창 닫기 = 숨김(Windows와 동일). Epic이 `Shell_NotifyIcon`으로 등록한 트레이 아이콘을 winemac systray가 **macOS 메뉴바 NSStatusItem**으로 올리고(`+systray` 트레이스로 확인), **우클릭** 메뉴로 창 열기·Exit가 된다 — 사용자 검증 완료. 좌클릭은 WM_LBUTTONDOWN/UP+NIN_SELECT까지 정상 전달되지만 Epic이 반응하지 않는다(Windows에서도 메뉴 기반). 시도했다 버린 것들: exe 재실행·`com.epicgames.launcher://` URL은 실행 중 인스턴스가 무시; 외부에서 `ShowWindow(SW_SHOW/RESTORE)`로 숨긴 창을 띄우면 보이긴 하지만 Slate가 "최소화" 상태를 유지해 **입력을 안 받는 먹통 창**이 된다. 그래서 Epic 모드는 `WINE_DOCK_REOPEN_CMD`를 쓰지 않는다.
 - 부수 수정: `WINE_DOCK_REOPEN_CMD` 훅의 "보이는 창" 판정이 Epic의 화면 밖(-10000,-10000) 1×1 투명 보조창을 보이는 창으로 세던 것을 실제 화면 안·alpha>0·크기>1 조건으로 고쳤고, `build-engine.sh`가 CX 엔진에도 winemac 패치를 적용한다.
 
 결론: 벽 1(`WRITECOPY`)은 libcef 버전에 따라 걸리는 일반 문제일 수 있지만, 벽 1-b(GPU 프로세스 사망)는 Battle.net의 CEF 빌드/설정 고유. 다른 CEF 런처(GOG Galaxy·EA app·Ubisoft Connect)도 같은 절차로 먼저 "그냥 돌려보는" 것이 맞다.

--- a/install.sh
+++ b/install.sh
@@ -27,7 +27,9 @@ if [ -x "$ENGINE/bin/wine" ]; then
   say "[1/4] Engine already present - skipping"
 else
   say "[1/4] Downloading prebuilt engine (~350MB, GPL - built from CodeWeavers' published Wine sources)"
-  URL=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" \
+  # The engine ships on its own "engine-*" release, which is not necessarily the
+  # newest release — scan all releases and take the first (newest) engine asset.
+  URL=$(curl -fsSL "https://api.github.com/repos/$REPO/releases?per_page=30" \
         | grep -o '"browser_download_url": *"[^"]*soju-engine[^"]*"' | head -1 | grep -o 'https[^"]*')
   [ -n "$URL" ] || { echo "Could not find the engine release asset."; exit 1; }
   curl -fL "$URL" -o "$BASE/engine.tar.xz"

--- a/patches/winemac-no-dock-icon.patch
+++ b/patches/winemac-no-dock-icon.patch
@@ -1,5 +1,5 @@
 diff --git a/dlls/winemac.drv/cocoa_app.m b/dlls/winemac.drv/cocoa_app.m
-index 2a9dab2..7d41ce8 100644
+index 2a9dab2..13e054b 100644
 --- a/dlls/winemac.drv/cocoa_app.m
 +++ b/dlls/winemac.drv/cocoa_app.m
 @@ -230,6 +230,34 @@ - (void) transformProcessToForeground:(BOOL)activateIfTransformed
@@ -37,7 +37,7 @@ index 2a9dab2..7d41ce8 100644
              [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
  
              if (activateIfTransformed)
-@@ -2232,6 +2260,34 @@ - (BOOL) applicationShouldHandleReopen:(NSApplication*)theApplication hasVisible
+@@ -2232,6 +2260,40 @@ - (BOOL) applicationShouldHandleReopen:(NSApplication*)theApplication hasVisible
          // Note that "flag" is often wrong.  WineWindows are NSPanels and NSPanels
          // don't count as "visible windows" for this purpose.
          [self unminimizeWindowIfNoneVisible];
@@ -53,10 +53,16 @@ index 2a9dab2..7d41ce8 100644
 +                BOOL anyVisible = NO;
 +                for (NSWindow* w in [NSApp windows])
 +                {
-+                    if ([w isKindOfClass:[WineWindow class]] && [w isVisible] && ![w isMiniaturized])
++                    /* Only count windows a user can actually see. Tray-parked apps
++                       (Epic Games Launcher) keep tiny transparent helper windows
++                       parked far off-screen, and those are still "visible" to AppKit. */
++                    if ([w isKindOfClass:[WineWindow class]] && [w isVisible] && ![w isMiniaturized]
++                        && [w alphaValue] > 0.0 && w.frame.size.width > 1 && w.frame.size.height > 1)
 +                    {
-+                        anyVisible = YES;
-+                        break;
++                        BOOL onScreen = NO;
++                        for (NSScreen* screen in [NSScreen screens])
++                            if (NSIntersectsRect(w.frame, screen.frame)) { onScreen = YES; break; }
++                        if (onScreen) { anyVisible = YES; break; }
 +                    }
 +                }
 +                if (!anyVisible)

--- a/scripts/build-engine.sh
+++ b/scripts/build-engine.sh
@@ -27,6 +27,13 @@ echo "==> Downloading CrossOver 26.3 sources + freetype"
 [ -f "$WORK/cx-src.tar.gz" ] || curl -fL "$SRC_URL" -o "$WORK/cx-src.tar.gz"
 tar -xzf "$WORK/cx-src.tar.gz" -C "$WORK" sources/wine
 WINE="$WORK/sources/wine"
+# Soju winemac patch: WINE_NO_DOCK_ICON (hide helper-process Dock icons) and
+# WINE_DOCK_REOPEN_CMD (Dock click brings a tray-parked launcher back). Used by
+# the Epic and Steam modes of play.sh.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if ! grep -q WINE_DOCK_REOPEN_CMD "$WINE/dlls/winemac.drv/cocoa_app.m"; then
+  patch -p1 -d "$WINE" < "$SCRIPT_DIR/../patches/winemac-no-dock-icon.patch"
+fi
 
 echo "==> Building x86_64 freetype (Rosetta)"
 [ -f "$WORK/ft.tar.gz" ] || curl -fL "$FT_URL" -o "$WORK/ft.tar.gz"

--- a/scripts/create-epic-bottle.sh
+++ b/scripts/create-epic-bottle.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Create a bottle for the Epic Games Launcher on the free CX-source engine and
+# install it with Epic's official MSI.
+# Verified 2026-08-29 (M4 Pro / macOS 26.5): unattended install (~30 s), launcher
+# UI renders, login works. No launcher-specific hacks were needed beyond the
+# Battle.net environment — Epic's CEF (EpicWebHelper) keeps its GPU process
+# alive on this engine, so no --in-process-gpu switch either.
+set -euo pipefail
+
+ENGINE="${ENGINE:-$HOME/.battlenet-macos/cx26-engine}"
+export WINEPREFIX="${WINEPREFIX:-$HOME/.battlenet-macos/epic-bottle}"
+export WINEDEBUG="${WINEDEBUG:-fixme-all}"
+export WINEMSYNC=1 ROSETTA_ADVERTISE_AVX=1 WINE_SIMULATE_WRITECOPY=1
+export CX_APPLEGPTK_LIBD3DSHARED_PATH="$ENGINE/lib/external/libd3dshared.dylib"
+export DYLD_FALLBACK_LIBRARY_PATH="$ENGINE/lib:/usr/lib"
+
+[ -x "$ENGINE/bin/wine" ] || { echo "Engine not found — run install.sh (or build-engine.sh) first"; exit 1; }
+[ -f "$CX_APPLEGPTK_LIBD3DSHARED_PATH" ] || { echo "libd3dshared not found — run get-gptk.sh first"; exit 1; }
+
+WORK="${WORK:-$HOME/.battlenet-macos/build}"; mkdir -p "$WORK"
+W="$ENGINE/bin/wine"
+
+echo "==> Initializing the prefix: $WINEPREFIX"
+"$W" wineboot -u >/dev/null 2>&1 || true
+"$ENGINE/bin/wineserver" -w
+"$W" reg add "HKCU\\Software\\Wine\\WineDbg" /v ShowCrashDialog /t REG_DWORD /d 0 /f >/dev/null 2>&1
+"$ENGINE/bin/wineserver" -w
+
+echo "==> Downloading the Epic Games Launcher installer (official Epic MSI)"
+MSI="$WORK/EpicGamesLauncherInstaller.msi"
+[ -f "$MSI" ] || curl -fL "https://launcher-public-service-prod06.ol.epicgames.com/launcher/api/installer/download/EpicGamesLauncherInstaller.msi" -o "$MSI"
+
+echo "==> Running the installer (unattended, about half a minute)"
+"$W" msiexec /i "$MSI" /qn >/dev/null 2>&1 || true
+"$ENGINE/bin/wineserver" -w
+
+EXE="$WINEPREFIX/drive_c/Program Files/Epic Games/Launcher/Portal/Binaries/Win64/EpicGamesLauncher.exe"
+[ -f "$EXE" ] || { echo "Install failed — try: WINEDEBUG=+msi $W msiexec /i \"$MSI\""; exit 1; }
+echo "==> Epic Games Launcher installed"
+"$ENGINE/bin/wineserver" -k 2>/dev/null || true
+echo "==> Done. Now run: scripts/play.sh epic   (log in, then install games from the launcher)"

--- a/scripts/play.sh
+++ b/scripts/play.sh
@@ -20,6 +20,8 @@ MODE="${1:-battlenet}"
 # Bottle (virtual C: drive) path — per-mode default (Battle.net and Steam use separate bottles)
 if [[ "$MODE" == steam* ]]; then
   export WINEPREFIX="${WINEPREFIX:-$HOME/.battlenet-macos/steam-bottle}"
+elif [[ "$MODE" == epic* ]]; then
+  export WINEPREFIX="${WINEPREFIX:-$HOME/.battlenet-macos/epic-bottle}"
 else
   export WINEPREFIX="${WINEPREFIX:-$HOME/.battlenet-macos/bottle}"
 fi
@@ -71,6 +73,23 @@ case "$MODE" in
     start_reaper
     cd "$WINEPREFIX/drive_c/Program Files (x86)/Diablo II Resurrected"
     exec "$ENGINE/bin/wine" "D2R.exe" "${@:2}"
+    ;;
+  epic)        # Epic Games Launcher — same engine and env as Battle.net (verified 2026-08-29)
+    # Runs as-is: Epic's CEF (EpicWebHelper) keeps its GPU process alive here,
+    # so none of the Battle.net command-line switches are needed. Closing the
+    # window parks the launcher in its (invisible) tray, like on Windows; a Dock
+    # click re-runs the exe, which just raises the running instance.
+    EPIC="C:\\Program Files\\Epic Games\\Launcher\\Portal\\Binaries\\Win64\\EpicGamesLauncher.exe"
+    [[ -f "$WINEPREFIX/drive_c/Program Files/Epic Games/Launcher/Portal/Binaries/Win64/EpicGamesLauncher.exe" ]] || \
+      { echo "Epic Games Launcher not found — run scripts/create-epic-bottle.sh first"; exit 1; }
+    pgrep -f "soju-reaper.sh $WINEPREFIX" >/dev/null 2>&1 || \
+      { [ -x "$REAPER" ] && ( "$REAPER" "$WINEPREFIX" "$ENGINE/bin/wineserver" epic >/dev/null 2>&1 & ); }
+    export WINE_DOCK_REOPEN_CMD="'$ENGINE/bin/wine' '$EPIC'"
+    exec "$ENGINE/bin/wine" "$EPIC" "${@:2}"
+    ;;
+  epic-kill)   # Stop everything in the Epic bottle
+    pkill -f "soju-reaper.sh $WINEPREFIX" 2>/dev/null || true
+    "$ENGINE/bin/wineserver" -k 2>/dev/null || true
     ;;
   steam)       # Steam client — wine-stable + webhelper wrapper (verified 2026-08-27)
     # Steam's CEF does not render on the CX engine (black screen / SEGV storm).
@@ -147,5 +166,5 @@ case "$MODE" in
     pkill -f "soju-reaper.sh $WINEPREFIX" 2>/dev/null || true
     "/Applications/Wine Stable.app/Contents/Resources/wine/bin/wineserver" -k 2>/dev/null || true
     ;;
-  *) echo "usage: play.sh [battlenet|d2r|steam|kill|steam-kill]"; exit 1;;
+  *) echo "usage: play.sh [battlenet|d2r|epic|epic-kill|steam|kill|steam-kill]"; exit 1;;
 esac

--- a/scripts/play.sh
+++ b/scripts/play.sh
@@ -79,7 +79,7 @@ case "$MODE" in
     # so none of the Battle.net command-line switches are needed.
     # Closing the window hides it, exactly like on Windows: Epic's tray icon
     # lands in the macOS menu bar (winemac systray -> NSStatusItem), and its
-    # menu reopens the window or exits. Do NOT force the hidden window back via
+    # right-click menu reopens the window or exits (left click is ignored by Epic). Do NOT force the hidden window back via
     # ShowWindow() from outside — Slate keeps its "minimized" state and the
     # window comes back unresponsive.
     EPIC="C:\\Program Files\\Epic Games\\Launcher\\Portal\\Binaries\\Win64\\EpicGamesLauncher.exe"

--- a/scripts/play.sh
+++ b/scripts/play.sh
@@ -76,15 +76,17 @@ case "$MODE" in
     ;;
   epic)        # Epic Games Launcher — same engine and env as Battle.net (verified 2026-08-29)
     # Runs as-is: Epic's CEF (EpicWebHelper) keeps its GPU process alive here,
-    # so none of the Battle.net command-line switches are needed. Closing the
-    # window parks the launcher in its (invisible) tray, like on Windows; a Dock
-    # click re-runs the exe, which just raises the running instance.
+    # so none of the Battle.net command-line switches are needed.
+    # Closing the window hides it, exactly like on Windows: Epic's tray icon
+    # lands in the macOS menu bar (winemac systray -> NSStatusItem), and its
+    # menu reopens the window or exits. Do NOT force the hidden window back via
+    # ShowWindow() from outside — Slate keeps its "minimized" state and the
+    # window comes back unresponsive.
     EPIC="C:\\Program Files\\Epic Games\\Launcher\\Portal\\Binaries\\Win64\\EpicGamesLauncher.exe"
     [[ -f "$WINEPREFIX/drive_c/Program Files/Epic Games/Launcher/Portal/Binaries/Win64/EpicGamesLauncher.exe" ]] || \
       { echo "Epic Games Launcher not found — run scripts/create-epic-bottle.sh first"; exit 1; }
     pgrep -f "soju-reaper.sh $WINEPREFIX" >/dev/null 2>&1 || \
       { [ -x "$REAPER" ] && ( "$REAPER" "$WINEPREFIX" "$ENGINE/bin/wineserver" epic >/dev/null 2>&1 & ); }
-    export WINE_DOCK_REOPEN_CMD="'$ENGINE/bin/wine' '$EPIC'"
     exec "$ENGINE/bin/wine" "$EPIC" "${@:2}"
     ;;
   epic-kill)   # Stop everything in the Epic bottle

--- a/scripts/soju
+++ b/scripts/soju
@@ -6,13 +6,17 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 usage() {
   cat <<'EOF'
-soju — free Battle.net / Diablo II: Resurrected / Steam on Apple Silicon
+soju — free Battle.net / Diablo II: Resurrected / Epic / Steam on Apple Silicon
 
 Usage:
   soju install        Set up the Wine engine, Apple GPTK and Battle.net
   soju battlenet      Launch Battle.net (default bottle)
   soju d2r            Launch Diablo II: Resurrected directly
   soju kill           Stop everything in the Battle.net bottle
+
+  soju epic-install   Set up the Epic Games Launcher bottle (same engine)
+  soju epic           Launch the Epic Games Launcher
+  soju epic-kill      Stop everything in the Epic bottle
 
   soju steam-install  Set up the Steam bottle (wine-stable + wrapper + Steam)
   soju steam-games    Wire DXMT so D3D11 games render (needs built artifacts)
@@ -25,9 +29,10 @@ EOF
 
 case "${1:-}" in
   install)        shift; exec bash "$ROOT/install.sh" "$@" ;;
+  epic-install)   shift; exec bash "$ROOT/scripts/create-epic-bottle.sh" "$@" ;;
   steam-install)  shift; exec bash "$ROOT/scripts/create-steam-bottle.sh" "$@" ;;
   steam-games)    shift; exec bash "$ROOT/scripts/setup-steam-games.sh" "$@" ;;
-  battlenet|d2r|steam|kill|steam-kill)
+  battlenet|d2r|epic|epic-kill|steam|kill|steam-kill)
                   exec bash "$ROOT/scripts/play.sh" "$@" ;;
   -h|--help|help|"") usage ;;
   *) echo "soju: unknown command '$1'" >&2; usage >&2; exit 64 ;;

--- a/scripts/soju-reaper.sh
+++ b/scripts/soju-reaper.sh
@@ -11,15 +11,16 @@
 # Window detection uses CGWindowListCopyWindowInfo via python3+ctypes — no
 # Accessibility permission needed, nothing to install.
 #
-# Usage: soju-reaper.sh <WINEPREFIX> <wineserver-path> [battlenet|steam]
+# Usage: soju-reaper.sh <WINEPREFIX> <wineserver-path> [battlenet|steam|epic]
 #        (backgrounded by play.sh / the Battle.net.app launcher)
 #
 # steam mode: closing the Steam window parks it in a tray (as on Windows; the
 # Dock icon brings it back via WINE_DOCK_REOPEN_CMD). Once steam.exe itself has
 # exited, the leftovers (steamservice, winedevice, wineserver) are shut down.
+# epic mode: same tray semantics, keyed on EpicGamesLauncher.exe.
 set -u
 
-PREFIX="${1:?usage: soju-reaper.sh <WINEPREFIX> <wineserver> [battlenet|steam]}"
+PREFIX="${1:?usage: soju-reaper.sh <WINEPREFIX> <wineserver> [battlenet|steam|epic]}"
 WINESERVER="${2:?}"
 MODE="${3:-battlenet}"
 INTERVAL=20
@@ -27,6 +28,12 @@ case "$MODE" in
   steam)
     GAME_RE='Steam\\steamapps\\'                      # games live under steamapps
     UI_RE='steam\.exe|steamwebhelper'
+    TRAY_RE='steam\.exe'; TRAY_KILL_RE="$UI_RE|steamservice\.exe"
+    ;;
+  epic)
+    GAME_RE='__none__'
+    UI_RE='EpicGamesLauncher\.exe|EpicWebHelper\.exe|EpicOnlineServices'
+    TRAY_RE='EpicGamesLauncher\.exe'; TRAY_KILL_RE="$UI_RE"
     ;;
   *)
     GAME_RE='D2R\.exe|BlizzardError\.exe'
@@ -67,18 +74,18 @@ PY
 declare -A STRIKES
 IDLE_STRIKES=0
 
-if [ "$MODE" = "steam" ]; then
+if [ "$MODE" = "steam" ] || [ "$MODE" = "epic" ]; then
   # Steam parks itself in an (invisible on macOS) tray when its window is closed,
   # so a missing window means nothing here. Only once steam.exe has really gone
   # (Steam menu > Exit) do we shut the rest of the bottle down.
   while true; do
     sleep "$INTERVAL"
-    if ! pgrep -f 'steam\.exe' >/dev/null 2>&1; then
+    if ! pgrep -f "$TRAY_RE" >/dev/null 2>&1; then
       IDLE_STRIKES=$((IDLE_STRIKES + 1))
       if [ "$IDLE_STRIKES" -ge 2 ]; then
         WINEPREFIX="$PREFIX" "$WINESERVER" -k 2>/dev/null || true
         sleep 3
-        pkill -9 -f "$UI_RE|steamservice\.exe" 2>/dev/null || true
+        pkill -9 -f "$TRAY_KILL_RE" 2>/dev/null || true
         exit 0
       fi
     else


### PR DESCRIPTION
## What
- **Epic Games Launcher** on the same CX-source engine: `scripts/create-epic-bottle.sh` (official MSI, unattended ~30 s), `play.sh epic` / `epic-kill`, `soju epic-install|epic|epic-kill`, reaper `epic` mode (teardown once `EpicGamesLauncher.exe` exits).
- Tray UX is the Windows one: closing the window hides it, and Epic's tray icon shows up in the **macOS menu bar** (winemac systray → NSStatusItem); its menu reopens the window / exits. No Dock-reopen hook for Epic — forcing the hidden window back via ShowWindow() leaves Slate "minimized" (unresponsive), and a second instance / `com.epicgames.launcher://` are ignored (details in DIAGNOSIS.md).
- `build-engine.sh` applies `patches/winemac-no-dock-icon.patch` to the CX engine too; the patch's reopen hook now ignores off-screen 1×1 transparent helper windows when deciding whether anything is visible.
- **install.sh fix**: the engine asset lives on the `engine-*` release, but the script queried `releases/latest`. Since `v1.1-steam` became latest (2026-08-28) fresh installs failed at step 1 ("Could not find the engine release asset"). Now scans all releases for the newest engine asset.
- README / README.ko / DIAGNOSIS: Epic section.

## Verified (M4 Pro, macOS 26.5, 2026-08-29)
- MSI install, launcher UI, login — no Battle.net-style `--in-process-gpu` switches needed (Epic's CEF GPU process survives).
- Close window → menu-bar tray icon → Exit → reaper tears the bottle down (no leftover explorer/winedevice/wineserver).

## Follow-up after merge
- Upload a rebuilt `soju-engine-x86_64.tar.xz` (patched winemac) as `engine-v1.1` so one-line installer users get the same winemac.

https://claude.ai/code/session_01TiFcqQceFHoQLeJXf63twY