### PR TITLE
Sweep orphaned Wine service processes after teardown

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ Verified on M4 Pro / macOS 26.5: login, library, and an actual D3D11 (Unity) gam
 - **Battle.net login webview may flicker (~once a minute)** -> known cosmetic issue; it recovers automatically and login works.
 - **BLZBNTBNA00000005** -> `play.sh` seeds the signed exe automatically; make sure you launch through it.
 
+### Leftover Wine processes
+
+Every bottle start also spawns idle Windows service processes (`services.exe`, `winedevice.exe`, `plugplay.exe`, `rpcss.exe`, `explorer.exe /desktop`, ~100 MB per set). If a bottle's `wineserver` is killed abruptly (a crash, an aborted run), those services never notice and linger. `scripts/soju-sweep.sh` removes them, and `play.sh kill` / `epic-kill` / `steam-kill` and the reaper call it automatically — but only when no `wineserver` is running at all, so a live game or launcher is never touched.
+
 ## What's in the repo
 
 - `scripts/build-engine.sh` — full engine build recipe (freetype cross-build, gnutls wiring, GPTK layout, entitlements)

--- a/scripts/play.sh
+++ b/scripts/play.sh
@@ -50,6 +50,7 @@ if [[ -f "$BN/Battle.net.exe" ]]; then
 fi
 
 REAPER="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/soju-reaper.sh"
+SWEEP="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/soju-sweep.sh"   # orphaned-service cleanup
 start_reaper(){
   # Watchdog: reaps game processes that outlive their windows, and shuts the
   # prefix down once everything is closed — so "quit" really means quit.
@@ -92,6 +93,7 @@ case "$MODE" in
   epic-kill)   # Stop everything in the Epic bottle
     pkill -f "soju-reaper.sh $WINEPREFIX" 2>/dev/null || true
     "$ENGINE/bin/wineserver" -k 2>/dev/null || true
+    sleep 2; [ -x "$SWEEP" ] && "$SWEEP"
     ;;
   steam)       # Steam client — wine-stable + webhelper wrapper (verified 2026-08-27)
     # Steam's CEF does not render on the CX engine (black screen / SEGV storm).
@@ -160,6 +162,7 @@ case "$MODE" in
   kill)        # Stop everything in the Battle.net bottle
     pkill -f "soju-reaper.sh" 2>/dev/null || true
     "$ENGINE/bin/wineserver" -k 2>/dev/null || true
+    sleep 2; [ -x "$SWEEP" ] && "$SWEEP"
     ;;
   steam-kill)  # Stop everything in the Steam bottle — note this bottle runs on
     # wine-stable, so it needs wine-stable's wineserver. Killing the CX engine's
@@ -167,6 +170,7 @@ case "$MODE" in
     # respawning steamwebhelper (it looks like "Steam relaunches itself").
     pkill -f "soju-reaper.sh $WINEPREFIX" 2>/dev/null || true
     "/Applications/Wine Stable.app/Contents/Resources/wine/bin/wineserver" -k 2>/dev/null || true
+    sleep 2; [ -x "$SWEEP" ] && "$SWEEP"
     ;;
   *) echo "usage: play.sh [battlenet|d2r|epic|epic-kill|steam|kill|steam-kill]"; exit 1;;
 esac

--- a/scripts/soju-reaper.sh
+++ b/scripts/soju-reaper.sh
@@ -24,6 +24,7 @@ PREFIX="${1:?usage: soju-reaper.sh <WINEPREFIX> <wineserver> [battlenet|steam|ep
 WINESERVER="${2:?}"
 MODE="${3:-battlenet}"
 INTERVAL=20
+SWEEP="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/soju-sweep.sh"
 case "$MODE" in
   steam)
     GAME_RE='Steam\\steamapps\\'                      # games live under steamapps
@@ -84,6 +85,7 @@ if [ "$MODE" = "steam" ] || [ "$MODE" = "epic" ]; then
       IDLE_STRIKES=$((IDLE_STRIKES + 1))
       if [ "$IDLE_STRIKES" -ge 2 ]; then
         WINEPREFIX="$PREFIX" "$WINESERVER" -k 2>/dev/null || true
+        sleep 3; [ -x "$SWEEP" ] && "$SWEEP" >/dev/null 2>&1
         sleep 3
         pkill -9 -f "$TRAY_KILL_RE" 2>/dev/null || true
         exit 0
@@ -106,6 +108,7 @@ while true; do
     # Two idle checks in a row: tear down leftover services (Agent, winedevice…)
     if [ "$IDLE_STRIKES" -ge 2 ]; then
       WINEPREFIX="$PREFIX" "$WINESERVER" -k 2>/dev/null || true
+      sleep 3; [ -x "$SWEEP" ] && "$SWEEP" >/dev/null 2>&1
       exit 0
     fi
     continue

--- a/scripts/soju-sweep.sh
+++ b/scripts/soju-sweep.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# soju-sweep — remove orphaned Wine service processes.
+#
+# Every bottle start spawns a set of idle Windows "system" processes
+# (services.exe, winedevice.exe x2, plugplay.exe, rpcss.exe, explorer.exe
+# /desktop — ~100 MB together). When the bottle's wineserver is killed
+# (wineserver -k, a crashed launcher, an aborted test) the apps die, but these
+# sleeping services never talk to the server again and so never notice it is
+# gone; they linger for hours. This sweeps them — but ONLY when no wineserver
+# is running at all, i.e. when nothing in any bottle can still be alive, so a
+# running game or launcher is never touched.
+#
+# Usage: soju-sweep.sh        (called by play.sh *-kill and by soju-reaper.sh)
+set -u
+if pgrep -x wineserver >/dev/null 2>&1 || pgrep -x wineserver64 >/dev/null 2>&1; then
+  exit 0   # something is live — do nothing
+fi
+RE='(explorer\.exe /desktop|services\.exe|winedevice\.exe|plugplay\.exe|rpcss\.exe|svchost\.exe|conhost\.exe|tabtip\.exe)'
+PIDS=$(pgrep -f "$RE" 2>/dev/null || true)
+[ -n "$PIDS" ] || exit 0
+echo "soju-sweep: removing orphaned Wine services: $(echo $PIDS | wc -w | tr -d ' ') processes"
+kill -9 $PIDS 2>/dev/null || true


### PR DESCRIPTION
Idle Wine service processes (services.exe, winedevice, plugplay, rpcss, explorer /desktop) outlive a killed wineserver and linger for hours (~100 MB per set; 7 sets found after a day of debugging). `scripts/soju-sweep.sh` removes them, but only when no wineserver is running at all, so nothing live is ever touched. Called from `play.sh kill/epic-kill/steam-kill` and from the reaper's teardown. README note added.

Verified 2026-08-29: swept 34 orphaned processes on this machine with Battle.net/Steam/Epic all stopped.

https://claude.ai/code/session_01TiFcqQceFHoQLeJXf63twY