### PR TITLE
sweep: also remove orphaned Wine prompts

### DIFF
--- a/scripts/soju-sweep.sh
+++ b/scripts/soju-sweep.sh
@@ -15,7 +15,9 @@ set -u
 if pgrep -x wineserver >/dev/null 2>&1 || pgrep -x wineserver64 >/dev/null 2>&1; then
   exit 0   # something is live — do nothing
 fi
-RE='(explorer\.exe /desktop|services\.exe|winedevice\.exe|plugplay\.exe|rpcss\.exe|svchost\.exe|conhost\.exe|tabtip\.exe)'
+# Also Wine's own prompts (the "Wine Mono Installer" dialog is control.exe
+# appwiz.cpl install_mono) — orphaned, they sit in the Dock as "wine" for hours.
+RE='(explorer\.exe /desktop|services\.exe|winedevice\.exe|plugplay\.exe|rpcss\.exe|svchost\.exe|conhost\.exe|tabtip\.exe|control\.exe appwiz\.cpl|wineboot\.exe|winedbg\.exe)'
 PIDS=$(pgrep -f "$RE" 2>/dev/null || true)
 [ -n "$PIDS" ] || exit 0
 echo "soju-sweep: removing orphaned Wine services: $(echo $PIDS | wc -w | tr -d ' ') processes"


### PR DESCRIPTION
A 'Wine Mono Installer' dialog (control.exe appwiz.cpl install_mono) from an aborted test bottle survived its wineserver for 10+ hours and sat in the Dock as a bare 'wine' icon. Add Wine's own prompt/helper processes to the sweep set (same no-wineserver-running guard).

https://claude.ai/code/session_01TiFcqQceFHoQLeJXf63twY