### PR TITLE
README: lead with the launcher-login fixes

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -2,11 +2,13 @@
 
 > *Wine → Whisky → Kegworks… 그리고 한국의 차례: **Soju** 🍶*
 
-**Apple Silicon 맥에서 Battle.net·디아블로 II: 레저렉션·Epic Games Launcher·Steam을 — 완전 무료 오픈소스 Wine 스택으로.**
+**런처가 실제로 로그인됩니다.** Apple Silicon 맥에서 Battle.net·Steam·Epic Games Launcher — 검은 로그인 창도, 끝나지 않는 "Signing in…"도, CrossOver 라이선스도 없이. 완전 무료 오픈소스 Wine 스택.
+
+Whisky/Kegworks 스레드의 *"배틀넷 로그인 시 크래시"*, *"Steam이 안 열림"*, *"런처 창이 비어 있음"* 때문에 오셨다면, 바로 그 벽들을 이 레포가 기록하고 해결했습니다(CEF 렌더러 `PAGE_WRITECOPY` int3, CEF GPU 프로세스 초기화 사망, Steam webhelper) — [docs/DIAGNOSIS.md](docs/DIAGNOSIS.md).
 
 CodeWeavers가 GPL로 공개한 소스(Wine 11.0, CrossOver 26.3 소스 드롭)를 이 레포의 스크립트로 직접 빌드·조립합니다. 유료 소프트웨어 불필요.
 
-> 상태(2026-08): **전 구간 동작** — 배틀넷 로그인, Agent, D2R 인게임 렌더링(D3DMetal)까지. M4 Pro / macOS 26.5에서 검증.
+> 상태(2026-08): **전 구간 동작** — 배틀넷 로그인·Agent·D2R 인게임 렌더링(D3DMetal), Epic Games Launcher 로그인(메뉴바 트레이), Steam 로그인 + D3D11 게임. M4 Pro / macOS 26.5에서 검증.
 
 *[English README](README.md)*
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 > *Wine → Whisky → Kegworks… and now a Korean round: **Soju** 🍶*
 
-**Run Battle.net, Diablo II: Resurrected, the Epic Games Launcher and Steam on Apple Silicon Macs — with a fully free, open-source Wine stack.**
+**The launchers actually log in.** Battle.net, Steam and the Epic Games Launcher on Apple Silicon — no black login window, no "Signing in…" that never ends, no CrossOver license. A fully free, open-source Wine stack.
+
+If you got here from a Whisky/Kegworks thread titled *"Battle.net crashes on login"*, *"Steam won't open"* or *"launcher shows a blank window"*: those are the exact walls this repo documents and fixes (CEF renderer `int3` on `PAGE_WRITECOPY`, CEF GPU process dying on init, Steam's webhelper) — see [docs/DIAGNOSIS.md](docs/DIAGNOSIS.md).
 
 Built from CodeWeavers' published GPL sources (Wine 11.0, CrossOver 26.3 source drop), compiled and assembled by scripts in this repo. No paid software required.
 
-> Status (2026-08): **Working end-to-end** — Battle.net login, Agent, and D2R in-game rendering (D3DMetal); Epic Games Launcher login; Steam client + D3D11 games. Verified on an M4 Pro running macOS 26.5.
+> Status (2026-08): **Working end-to-end** — Battle.net login, Agent, and D2R in-game rendering (D3DMetal); Epic Games Launcher login (tray icon in the menu bar); Steam client login + D3D11 games. Verified on an M4 Pro running macOS 26.5.
 
 *[한국어 README](README.ko.md)*
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,11 +3,11 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Soju — Free Battle.net, Diablo II: Resurrected &amp; Steam on Apple Silicon</title>
-<meta name="description" content="Soju is a free, open-source (GPL) toolchain that runs Battle.net, Diablo II: Resurrected and the Windows Steam client with D3D11 games on Apple Silicon Macs — no CrossOver license needed.">
+<title>Soju — Free Battle.net, Steam &amp; Epic launchers that actually log in on Apple Silicon</title>
+<meta name="description" content="Soju is a free, open-source (GPL) Wine stack where Battle.net, Steam and the Epic Games Launcher actually log in on Apple Silicon Macs — no black login window, no CrossOver license. Diablo II: Resurrected and D3D11 Steam games verified.">
 <link rel="canonical" href="https://bcd1210.github.io/soju/">
 <meta property="og:title" content="Soju — free Windows gaming on Apple Silicon">
-<meta property="og:description" content="Battle.net, Diablo II: Resurrected and the Windows Steam client on M-series Macs, fully free and open source.">
+<meta property="og:description" content="Battle.net, Steam and Epic Games Launcher logins that work on M-series Macs, fully free and open source.">
 <meta property="og:type" content="website">
 <link rel="stylesheet" href="style.css">
 </head>


### PR DESCRIPTION
The most-commented issues in Whisky/Sikarugir/D4Mac are all launcher logins and blank windows (Battle.net login crash 54c, 'Steam won't open' 41c+30c, blank launcher windows). That is exactly what this repo fixes, but the headline only listed products. Lead with it in README/README.ko and the site meta, and point Whisky/Kegworks refugees at DIAGNOSIS.md.

Checked: every README link returns 200, all scripts pass bash -n.

https://claude.ai/code/session_01TiFcqQceFHoQLeJXf63twY