### PR TITLE
Drop em dashes from docs, comments and messages

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,21 +1,21 @@
-Soju — third-party components and their licenses
+Soju: third-party components and their licenses
 
 Bundled in this repository:
-- third_party/steam-on-m1-wine/steamwebhelper-wrapper.c — MIT, Copyright (c) 2026 notpop
+- third_party/steam-on-m1-wine/steamwebhelper-wrapper.c: MIT, Copyright (c) 2026 notpop
   (see third_party/steam-on-m1-wine/LICENSE and NOTICE)
-- patches/winemac-no-dock-icon.patch — a patch against Wine's winemac.drv (Wine is LGPL-2.1+);
+- patches/winemac-no-dock-icon.patch: a patch against Wine's winemac.drv (Wine is LGPL-2.1+);
   the patch itself is offered under LGPL-2.1+ to match.
 
 Built or downloaded by the scripts (never redistributed by this repository):
-- Wine 11.0 — LGPL-2.1+ / GPL components, built from CodeWeavers' published sources
+- Wine 11.0: LGPL-2.1+ / GPL components, built from CodeWeavers' published sources
   (media.codeweavers.com/pub/crossover/source/)
-- DXMT — LGPL-2.1+, Copyright (c) 2023-2026 Feifan He for CodeWeavers
+- DXMT: LGPL-2.1+, Copyright (c) 2023-2026 Feifan He for CodeWeavers
   (built from the notpop fork of github.com/3Shain/dxmt)
-- wine-mono — MIT (dotnet parts MIT/BSD-like); MoltenVK — Apache-2.0; gnutls — LGPL-2.1+;
-  freetype — FTL/GPL-2.0 dual
-- Apple Game Porting Toolkit payload (libd3dshared/D3DMetal) — Apple proprietary,
+- wine-mono: MIT (dotnet parts MIT/BSD-like); MoltenVK: Apache-2.0; gnutls: LGPL-2.1+;
+  freetype: FTL/GPL-2.0 dual
+- Apple Game Porting Toolkit payload (libd3dshared/D3DMetal): Apple proprietary,
   NON-redistributable: users download it themselves from developer.apple.com
-- Blizzard Battle.net / game files and Valve Steam client — proprietary,
+- Blizzard Battle.net / game files and Valve Steam client: proprietary,
   installed by their own official installers into the user's prefix
 
 Trademarks: Battle.net and Diablo are trademarks of Blizzard Entertainment.

--- a/README.ko.md
+++ b/README.ko.md
@@ -2,13 +2,13 @@
 
 > *Wine → Whisky → Kegworks… 그리고 한국의 차례: **Soju** 🍶*
 
-**런처가 실제로 로그인됩니다.** Apple Silicon 맥에서 Battle.net·Steam·Epic Games Launcher — 검은 로그인 창도, 끝나지 않는 "Signing in…"도, CrossOver 라이선스도 없이. 완전 무료 오픈소스 Wine 스택.
+**런처가 실제로 로그인됩니다.** Apple Silicon 맥에서 Battle.net·Steam·Epic Games Launcher. 검은 로그인 창도, 끝나지 않는 "Signing in…"도, CrossOver 라이선스도 없이. 완전 무료 오픈소스 Wine 스택.
 
-Whisky/Kegworks 스레드의 *"배틀넷 로그인 시 크래시"*, *"Steam이 안 열림"*, *"런처 창이 비어 있음"* 때문에 오셨다면, 바로 그 벽들을 이 레포가 기록하고 해결했습니다(CEF 렌더러 `PAGE_WRITECOPY` int3, CEF GPU 프로세스 초기화 사망, Steam webhelper) — [docs/DIAGNOSIS.md](docs/DIAGNOSIS.md).
+Whisky/Kegworks 스레드의 *"배틀넷 로그인 시 크래시"*, *"Steam이 안 열림"*, *"런처 창이 비어 있음"* 때문에 오셨다면, 바로 그 벽들을 이 레포가 기록하고 해결했습니다(CEF 렌더러 `PAGE_WRITECOPY` int3, CEF GPU 프로세스 초기화 사망, Steam webhelper). [docs/DIAGNOSIS.md](docs/DIAGNOSIS.md).
 
 CodeWeavers가 GPL로 공개한 소스(Wine 11.0, CrossOver 26.3 소스 드롭)를 이 레포의 스크립트로 직접 빌드·조립합니다. 유료 소프트웨어 불필요.
 
-> 상태(2026-08): **전 구간 동작** — 배틀넷 로그인·Agent·D2R 인게임 렌더링(D3DMetal), Epic Games Launcher 로그인(메뉴바 트레이), Steam 로그인 + D3D11 게임. M4 Pro / macOS 26.5에서 검증.
+> 상태(2026-08): **전 구간 동작**: 배틀넷 로그인·Agent·D2R 인게임 렌더링(D3DMetal), Epic Games Launcher 로그인(메뉴바 트레이), Steam 로그인 + D3D11 게임. M4 Pro / macOS 26.5에서 검증.
 
 *[English README](README.md)*
 
@@ -16,9 +16,9 @@ CodeWeavers가 GPL로 공개한 소스(Wine 11.0, CrossOver 26.3 소스 드롭)�
 
 커뮤니티가 몇 달째 못 풀던 문제들의 해법:
 
-1. **`ROSETTA_ADVERTISE_AVX=1`** — D2R 로더는 AVX 명령어가 필수. 이 환경변수가 없으면 게임이 그래픽 초기화 전에 86MB/0%CPU로 영원히 멈춘다. "맥에서 D2R이 실행 안 됨"의 정체.
-2. **D3DMetal 심링크 레이아웃** — 애플 GPTK 라이브러리는 `lib/external/`에 실물을 두고, `lib/wine/x86_64-unix/`의 d3d10/11/12/dxgi.so는 **심링크**여야 한다. 복사하면 `@loader_path`가 어긋나 assertion 루프로 죽는다.
-3. **Battle.net Agent 서명검증 수정** — Agent는 접속한 클라이언트의 서명을 자기 작업폴더(버전 하위폴더) 기준 상대 파일명으로 검사한다. 서명된 `Battle.net.exe` 사본을 각 `Battle.net.NNNNN` 폴더에 넣으면 통과 (에러 `BLZBNTBNA00000005` 해결).
+1. **`ROSETTA_ADVERTISE_AVX=1`**: D2R 로더는 AVX 명령어가 필수. 이 환경변수가 없으면 게임이 그래픽 초기화 전에 86MB/0%CPU로 영원히 멈춘다. "맥에서 D2R이 실행 안 됨"의 정체.
+2. **D3DMetal 심링크 레이아웃**: 애플 GPTK 라이브러리는 `lib/external/`에 실물을 두고, `lib/wine/x86_64-unix/`의 d3d10/11/12/dxgi.so는 **심링크**여야 한다. 복사하면 `@loader_path`가 어긋나 assertion 루프로 죽는다.
+3. **Battle.net Agent 서명검증 수정**: Agent는 접속한 클라이언트의 서명을 자기 작업폴더(버전 하위폴더) 기준 상대 파일명으로 검사한다. 서명된 `Battle.net.exe` 사본을 각 `Battle.net.NNNNN` 폴더에 넣으면 통과 (에러 `BLZBNTBNA00000005` 해결).
 
 함정 하나: 실행 체인에 애플 보호 바이너리(`nohup`, `arch` 등)를 두면 macOS가 `DYLD_*` 변수를 제거해 라이브러리를 못 찾는다.
 
@@ -39,9 +39,9 @@ soju install     # 이후: soju battlenet / soju d2r / soju steam
 
 프리빌드 엔진(~350MB)을 받고, 애플 무료 GPTK 다운로드(애플이 재배포 금지한 파일 1개)를 안내하고, 블리자드 공식 설치기로 Battle.net을 자동 설치한 뒤 `~/Applications/Battle.net.app`을 만들어줍니다. 로그인하고 플레이하세요.
 
-## 직접 빌드하고 싶다면 — CrossOver 불필요
+## 직접 빌드하고 싶다면: CrossOver 불필요
 
-이 레포의 스크립트 밖에서 받는 것은 애플의 무료 Game Porting Toolkit 파일 하나뿐입니다 (무료 Apple ID 필요 — 애플이 재배포를 금지해서 직접 받아야 합니다).
+이 레포의 스크립트 밖에서 받는 것은 애플의 무료 Game Porting Toolkit 파일 하나뿐입니다 (무료 Apple ID 필요. 애플이 재배포를 금지해서 직접 받아야 합니다).
 
 ```bash
 # 1. 스크립트 받기
@@ -76,14 +76,14 @@ scripts/play.sh kill        # 전부 종료
 ```bash
 scripts/create-epic-bottle.sh    # 공식 Epic MSI, 무인 설치
 scripts/play.sh epic             # 로그인 → 게임 설치·플레이
-scripts/play.sh epic-kill        # Epic 보틀 종료 (창을 닫아도 런처는 살아 있음 — macOS 메뉴바의 Epic 아이콘을 **우클릭**해 열기/Exit, Windows 트레이와 동일 — 좌클릭 한 번엔 반응 없음)
+scripts/play.sh epic-kill        # Epic 보틀 종료 (창을 닫아도 런처는 살아 있음, macOS 메뉴바의 Epic 아이콘을 **우클릭**해 열기/Exit, Windows 트레이와 동일, 좌클릭 한 번엔 반응 없음)
 ```
 
 게임은 아직 폭넓게 테스트하지 않았습니다. 커널 안티치트(EAC/BattlEye)가 필요한 게임은 Wine에서 돌지 않습니다.
 
 ## Steam 지원 (Steam판 D2R 포함)
 
-D2R은 2026년 2월 Steam에도 *Infernal Edition*으로 출시됐습니다. Steam은 **다른 무료 엔진**을 씁니다: 최신 Steam 클라이언트의 CEF UI는 CrossOver 소스 계열 빌드에서 렌더링되지 않지만(검은 창 — 크로스 프로세스 스왑체인 + CEF 샌드박스 문제), homebrew `wine-stable` 11 + `steamwebhelper` 래퍼(`--disable-gpu --single-process` 강제)로는 동작합니다. 이 해법은 [notpop/steam-on-m1-wine](https://github.com/notpop/steam-on-m1-wine)(MIT, 래퍼 소스는 `third_party/`에 동봉)에서 왔습니다. Steam은 별도 보틀이라 두 스택이 서로 간섭하지 않습니다:
+D2R은 2026년 2월 Steam에도 *Infernal Edition*으로 출시됐습니다. Steam은 **다른 무료 엔진**을 씁니다: 최신 Steam 클라이언트의 CEF UI는 CrossOver 소스 계열 빌드에서 렌더링되지 않지만(검은 창, 크로스 프로세스 스왑체인 + CEF 샌드박스 문제), homebrew `wine-stable` 11 + `steamwebhelper` 래퍼(`--disable-gpu --single-process` 강제)로는 동작합니다. 이 해법은 [notpop/steam-on-m1-wine](https://github.com/notpop/steam-on-m1-wine)(MIT, 래퍼 소스는 `third_party/`에 동봉)에서 왔습니다. Steam은 별도 보틀이라 두 스택이 서로 간섭하지 않습니다:
 
 ```bash
 scripts/create-steam-bottle.sh   # wine-stable + 래퍼 + Valve 공식 설치기
@@ -91,13 +91,13 @@ scripts/play.sh steam            # 로그인 → 게임 설치·플레이
 scripts/play.sh steam-kill       # Steam 보틀 종료
 ```
 
-검증: M4 Pro / macOS 26.5 — 로그인·라이브러리·실제 D3D11(Unity) 게임 인게임 렌더링까지 (DXMT 포크). 전체 배선은 `docs/STEAM-GAMES.md` + `scripts/setup-steam-games.sh` 참고. 참고: Steam 입력 시 macOS 입력기를 영어(ABC)로 전환하세요 (한글 IME 조합이 `?`로 보입니다).
+검증: M4 Pro / macOS 26.5. 로그인·라이브러리·실제 D3D11(Unity) 게임 인게임 렌더링까지 (DXMT 포크). 전체 배선은 `docs/STEAM-GAMES.md` + `scripts/setup-steam-games.sh` 참고. 참고: Steam 입력 시 macOS 입력기를 영어(ABC)로 전환하세요 (한글 IME 조합이 `?`로 보입니다).
 
 **전제조건**: Apple Silicon 맥, Rosetta 2, Xcode CLT, Homebrew, 본인 배틀넷 계정, GPTK용 무료 Apple ID.
 
 ### GPTK가 왜 필요한가?
 
-GPTK 안의 `libd3dshared.dylib`는 그래픽만이 아닙니다 — **D2R 로더(안티치트)가 Rosetta 2를 통과하려면 이 파일의 '비네이티브 코드영역 등록' 기능이 필수**입니다. 없으면 AVX를 켜도 실행 직후 멈춥니다. 그래픽 자체는 D3DMetal 없이 순수 오픈소스 vkd3d/MoltenVK로도 돌아갑니다.
+GPTK 안의 `libd3dshared.dylib`는 그래픽만이 아닙니다. **D2R 로더(안티치트)가 Rosetta 2를 통과하려면 이 파일의 '비네이티브 코드영역 등록' 기능이 필수**입니다. 없으면 AVX를 켜도 실행 직후 멈춥니다. 그래픽 자체는 D3DMetal 없이 순수 오픈소스 vkd3d/MoltenVK로도 돌아갑니다.
 
 ### 문제 해결
 
@@ -110,6 +110,6 @@ GPTK 안의 `libd3dshared.dylib`는 그래픽만이 아닙니다 — **D2R 로�
 ## 라이선스
 
 - 이 레포의 스크립트·문서: **GPL-3.0**
-- 엔진은 CodeWeavers 공개 Wine 소스(GPL/LGPL)로 빌드 — 소스: `media.codeweavers.com/pub/crossover/source/`
+- 엔진은 CodeWeavers 공개 Wine 소스(GPL/LGPL)로 빌드. 소스: `media.codeweavers.com/pub/crossover/source/`
 - 미포함(앞으로도): 애플 D3DMetal/GPTK(재배포 금지), CrossOver 앱 바이너리, 블리자드 파일 일체
 - 본 프로젝트는 CodeWeavers·Apple·Blizzard와 무관합니다. Battle.net과 Diablo는 Blizzard Entertainment의 상표입니다.

--- a/README.md
+++ b/README.md
@@ -2,29 +2,29 @@
 
 > *Wine → Whisky → Kegworks… and now a Korean round: **Soju** 🍶*
 
-**The launchers actually log in.** Battle.net, Steam and the Epic Games Launcher on Apple Silicon — no black login window, no "Signing in…" that never ends, no CrossOver license. A fully free, open-source Wine stack.
+**The launchers actually log in.** Battle.net, Steam and the Epic Games Launcher on Apple Silicon. No black login window, no "Signing in…" that never ends, no CrossOver license. A fully free, open-source Wine stack.
 
-If you got here from a Whisky/Kegworks thread titled *"Battle.net crashes on login"*, *"Steam won't open"* or *"launcher shows a blank window"*: those are the exact walls this repo documents and fixes (CEF renderer `int3` on `PAGE_WRITECOPY`, CEF GPU process dying on init, Steam's webhelper) — see [docs/DIAGNOSIS.md](docs/DIAGNOSIS.md).
+If you got here from a Whisky/Kegworks thread titled *"Battle.net crashes on login"*, *"Steam won't open"* or *"launcher shows a blank window"*: those are the exact walls this repo documents and fixes (CEF renderer `int3` on `PAGE_WRITECOPY`, CEF GPU process dying on init, Steam's webhelper). See [docs/DIAGNOSIS.md](docs/DIAGNOSIS.md).
 
 Built from CodeWeavers' published GPL sources (Wine 11.0, CrossOver 26.3 source drop), compiled and assembled by scripts in this repo. No paid software required.
 
-> Status (2026-08): **Working end-to-end** — Battle.net login, Agent, and D2R in-game rendering (D3DMetal); Epic Games Launcher login (tray icon in the menu bar); Steam client login + D3D11 games. Verified on an M4 Pro running macOS 26.5.
+> Status (2026-08): **Working end-to-end**: Battle.net login, Agent, and D2R in-game rendering (D3DMetal); Epic Games Launcher login (tray icon in the menu bar); Steam client login + D3D11 games. Verified on an M4 Pro running macOS 26.5.
 
 *[한국어 README](README.ko.md)*
 
 ## Why this exists
 
-Community Wine builds (Whisky, Kegworks-era engines) stopped working with modern Battle.net and D2R. The commercial option works, but the underlying Wine engine is GPL — so we built it ourselves and documented every wall we hit. Three of those walls had never been publicly solved:
+Community Wine builds (Whisky, Kegworks-era engines) stopped working with modern Battle.net and D2R. The commercial option works, but the underlying Wine engine is GPL, so we built it ourselves and documented every wall we hit. Three of those walls had never been publicly solved:
 
 ### The three keys 🔑
 
-1. **`ROSETTA_ADVERTISE_AVX=1`** — D2R's loader requires AVX instructions. Without this env var, the game freezes forever at ~86 MB RSS with 0% CPU, before any graphics init. This is why D2R "hangs at launch" on non-CrossOver Wine builds.
+1. **`ROSETTA_ADVERTISE_AVX=1`**: D2R's loader requires AVX instructions. Without this env var, the game freezes forever at ~86 MB RSS with 0% CPU, before any graphics init. This is why D2R "hangs at launch" on non-CrossOver Wine builds.
 
-2. **D3DMetal symlink layout** — Apple's Game Porting Toolkit libraries must live in `lib/external/` with `lib/wine/x86_64-unix/{d3d10,d3d11,d3d12,dxgi}.so` as **symlinks** into it. Copying the files instead breaks `@loader_path` resolution and D3DMetal dies in an assertion loop.
+2. **D3DMetal symlink layout**: Apple's Game Porting Toolkit libraries must live in `lib/external/` with `lib/wine/x86_64-unix/{d3d10,d3d11,d3d12,dxgi}.so` as **symlinks** into it. Copying the files instead breaks `@loader_path` resolution and D3DMetal dies in an assertion loop.
 
-3. **Battle.net Agent caller-signature fix** — the Agent verifies the signature of the connecting client using a relative filename resolved against its CWD (a versioned subfolder). Seeding a copy of the signed `Battle.net.exe` into each `Battle.net.NNNNN` subfolder makes verification pass (fixes error `BLZBNTBNA00000005`).
+3. **Battle.net Agent caller-signature fix**: the Agent verifies the signature of the connecting client using a relative filename resolved against its CWD (a versioned subfolder). Seeding a copy of the signed `Battle.net.exe` into each `Battle.net.NNNNN` subfolder makes verification pass (fixes error `BLZBNTBNA00000005`).
 
-Plus one trap: never put Apple platform binaries (`nohup`, `arch`, …) in the launch chain — macOS strips `DYLD_*` variables when exec'ing them.
+Plus one trap: never put Apple platform binaries (`nohup`, `arch`, …) in the launch chain. macOS strips `DYLD_*` variables when exec'ing them.
 
 **Guides:** [D2R on Apple Silicon](https://bcd1210.github.io/soju/guides/diablo-2-resurrected-apple-silicon.html) · [Windows Steam client](https://bcd1210.github.io/soju/guides/steam-windows-client-apple-silicon.html) · [Whisky alternatives](https://bcd1210.github.io/soju/guides/whisky-alternative.html)
 
@@ -43,9 +43,9 @@ soju install     # then: soju battlenet / soju d2r / soju epic / soju steam
 
 Downloads the prebuilt engine (~350 MB), walks you through Apple's free GPTK download (the one file Apple forbids redistributing), auto-installs Battle.net with Blizzard's official installer, and drops a `Battle.net.app` in `~/Applications`. Log in and play.
 
-## Build it yourself instead — no CrossOver required
+## Build it yourself instead: no CrossOver required
 
-The only thing you download outside this repo's scripts is Apple's free Game Porting Toolkit (one file, needs a free Apple ID) — Apple forbids redistributing it.
+The only thing you download outside this repo's scripts is Apple's free Game Porting Toolkit (one file, needs a free Apple ID). Apple forbids redistributing it.
 
 ```bash
 # 1. Get the scripts
@@ -80,14 +80,14 @@ Same engine, own bottle, no extra tricks: Epic's CEF keeps its GPU process alive
 ```bash
 scripts/create-epic-bottle.sh    # official Epic MSI, unattended
 scripts/play.sh epic             # log in -> install & play
-scripts/play.sh epic-kill        # stop the Epic bottle (closing the window keeps the launcher running; right-click the Epic icon in the macOS menu bar to reopen or Exit — same as the Windows tray; a plain left click does nothing, as Epic only reacts to the menu)
+scripts/play.sh epic-kill        # stop the Epic bottle (closing the window keeps the launcher running; right-click the Epic icon in the macOS menu bar to reopen or Exit, same as the Windows tray; a plain left click does nothing, as Epic only reacts to the menu)
 ```
 
 Games have not been broadly tested yet; anything that needs kernel anti-cheat (EAC/BattlEye) will not run under Wine.
 
 ## Steam (including the Steam version of D2R)
 
-D2R shipped on Steam in Feb 2026 as the *Infernal Edition*. Steam support uses a **different free engine**: the modern Steam client's CEF UI does not render on CrossOver-source builds (black window — cross-process swapchain + CEF sandbox issues), but it works on Homebrew's `wine-stable` 11 with a tiny `steamwebhelper` wrapper that forces `--disable-gpu --single-process`. That fix comes from [notpop/steam-on-m1-wine](https://github.com/notpop/steam-on-m1-wine) (MIT — wrapper source vendored in `third_party/`). Steam gets its own bottle so the two stacks never interfere:
+D2R shipped on Steam in Feb 2026 as the *Infernal Edition*. Steam support uses a **different free engine**: the modern Steam client's CEF UI does not render on CrossOver-source builds (black window, cross-process swapchain + CEF sandbox issues), but it works on Homebrew's `wine-stable` 11 with a tiny `steamwebhelper` wrapper that forces `--disable-gpu --single-process`. That fix comes from [notpop/steam-on-m1-wine](https://github.com/notpop/steam-on-m1-wine) (MIT, wrapper source vendored in `third_party/`). Steam gets its own bottle so the two stacks never interfere:
 
 ```bash
 scripts/create-steam-bottle.sh   # installs wine-stable + wrapper + official Valve installer
@@ -95,13 +95,13 @@ scripts/play.sh steam            # log in -> install & play
 scripts/play.sh steam-kill       # stop the Steam bottle (closing the window keeps Steam running; click the Dock icon to bring it back, Steam > Exit quits)
 ```
 
-Verified on M4 Pro / macOS 26.5: login, library, and an actual D3D11 (Unity) game rendering in-game via a DXMT fork — see `docs/STEAM-GAMES.md` for the full wiring (`scripts/setup-steam-games.sh`). Notes: switch your macOS input source to English (ABC) when typing in Steam (IME composition shows as `?` otherwise).
+Verified on M4 Pro / macOS 26.5: login, library, and an actual D3D11 (Unity) game rendering in-game via a DXMT fork. See `docs/STEAM-GAMES.md` for the full wiring (`scripts/setup-steam-games.sh`). Notes: switch your macOS input source to English (ABC) when typing in Steam (IME composition shows as `?` otherwise).
 
 **Prerequisites**: Apple Silicon Mac, Rosetta 2, Xcode Command Line Tools, Homebrew, your own Battle.net account/games, and a free Apple ID for the GPTK download. Nothing from Apple, Blizzard, or CodeWeavers is redistributed by this repo.
 
 ### Why is GPTK needed at all?
 
-`libd3dshared.dylib` (inside GPTK) is not just graphics: D2R's loader requires its *non-native code region registration* to get through Rosetta 2 — without it the game freezes at launch even with AVX advertised. Graphics itself can run on pure open-source vkd3d/MoltenVK if D3DMetal is absent.
+`libd3dshared.dylib` (inside GPTK) is not just graphics: D2R's loader requires its *non-native code region registration* to get through Rosetta 2. Without it the game freezes at launch even with AVX advertised. Graphics itself can run on pure open-source vkd3d/MoltenVK if D3DMetal is absent.
 
 ### Troubleshooting
 
@@ -113,19 +113,19 @@ Verified on M4 Pro / macOS 26.5: login, library, and an actual D3D11 (Unity) gam
 
 ### Leftover Wine processes
 
-Every bottle start also spawns idle Windows service processes (`services.exe`, `winedevice.exe`, `plugplay.exe`, `rpcss.exe`, `explorer.exe /desktop`, ~100 MB per set). If a bottle's `wineserver` is killed abruptly (a crash, an aborted run), those services never notice and linger. `scripts/soju-sweep.sh` removes them, and `play.sh kill` / `epic-kill` / `steam-kill` and the reaper call it automatically — but only when no `wineserver` is running at all, so a live game or launcher is never touched.
+Every bottle start also spawns idle Windows service processes (`services.exe`, `winedevice.exe`, `plugplay.exe`, `rpcss.exe`, `explorer.exe /desktop`, ~100 MB per set). If a bottle's `wineserver` is killed abruptly (a crash, an aborted run), those services never notice and linger. `scripts/soju-sweep.sh` removes them, and `play.sh kill` / `epic-kill` / `steam-kill` and the reaper call it automatically. It only runs when no `wineserver` is running at all, so a live game or launcher is never touched.
 
 ## What's in the repo
 
-- `scripts/build-engine.sh` — full engine build recipe (freetype cross-build, gnutls wiring, GPTK layout, entitlements)
-- `scripts/setup-bottle.sh` / `scripts/play.sh` — bottle creation and the verified launch environment
-- `docs/DIAGNOSIS.md` — deep-dive on the CEF renderer crash and the Agent signature failure
-- `docs/D2R-GAME-LAUNCH.md` — the D2R loader investigation, dead ends included
-- `research/` — raw log evidence for the findings
+- `scripts/build-engine.sh`: full engine build recipe (freetype cross-build, gnutls wiring, GPTK layout, entitlements)
+- `scripts/setup-bottle.sh` / `scripts/play.sh`: bottle creation and the verified launch environment
+- `docs/DIAGNOSIS.md`: deep-dive on the CEF renderer crash and the Agent signature failure
+- `docs/D2R-GAME-LAUNCH.md`: the D2R loader investigation, dead ends included
+- `research/`: raw log evidence for the findings
 
 ## Licensing
 
 - Scripts and docs in this repo: **GPL-3.0** (see LICENSE)
-- The engine is built from CodeWeavers' published Wine sources (GPL/LGPL) — sources at `media.codeweavers.com/pub/crossover/source/`
+- The engine is built from CodeWeavers' published Wine sources (GPL/LGPL). Sources:  `media.codeweavers.com/pub/crossover/source/`
 - **Not included and never will be**: Apple D3DMetal/GPTK binaries (non-redistributable), CrossOver application binaries, any Blizzard files
 - This project is not affiliated with CodeWeavers, Apple, or Blizzard Entertainment. Battle.net and Diablo are trademarks of Blizzard Entertainment. Use at your own risk; online play with third-party compatibility layers is at your own discretion.

--- a/docs/D2R-GAME-LAUNCH.md
+++ b/docs/D2R-GAME-LAUNCH.md
@@ -1,4 +1,4 @@
-# 벽 3 — D2R 게임 본체 구동 (진행 중)
+# 벽 3: D2R 게임 본체 구동 (진행 중)
 
 로그인 + Agent + "playable" 인식까지 무료 스택으로 성공(벽1·2 해결). 그러나 **게임 본체 D2R.exe 실행**에서 막힘.
 
@@ -12,7 +12,7 @@
 
 ## 이 맥에서의 검증 (2026-08-26, macOS 26.5)
 - **진짜 CrossOver 26.3으로 D2R 실행 → 성공.** `[D3DMetal:LOG]` 렌더링, CPU 100%+, 게임 구동 확인. → macOS 26.5의 Rosetta 수정 + CrossOver 26.3 wine32on64가 조합되면 D2R 구동됨.
-- **무료 WineCX24(=CrossOver 24 커뮤니티 빌드)로는 실패** — 로더에서 정지. wine 버전이 너무 낮아 새 안티치트/Rosetta 경로 비호환.
+- **무료 WineCX24(=CrossOver 24 커뮤니티 빌드)로는 실패**: 로더에서 정지. wine 버전이 너무 낮아 새 안티치트/Rosetta 경로 비호환.
 - frankea/Whisky v4.5(=CX26.3 changes를 wine-11.15 new-wow64로 리베이스)는 **로그인 CEF에서 크래시**(new-wow64라 벽1 재발). → D2R은 될지 몰라도 로그인이 깨짐.
 
 ## 결론
@@ -21,8 +21,8 @@ D2R 완주에 필요한 것 = **CrossOver 26급 wine32on64**(구식 32-on-64 + �
 - frankea v4.5: 최신 로더 O, wine32on64 X(new-wow64) → 로그인 CEF 크래시
 
 ## 남은 선택지
-1. **CrossOver 26.3 GPL 소스로 wine32on64 직접 빌드** — 소스는 공개(`media.codeweavers.com/pub/crossover/source/crossover-sources-26.3.0.tar.gz`, 142MB, wine에 win32on64 지원 확인). 단, CrossOver의 빌드 오케스트레이션은 비공개라 빌드 과정을 재구성해야 함(대형 작업, Gcenx/Sikarugir 수준). D3DMetal(Apple GPTK, 소스 미포함)은 설치된 CrossOver에서 이식 가능(그래픽은 이미 검증됨).
-2. **커뮤니티 CX26 wine32on64 빌드 대기** — @dappermint가 CX26.3을 이미 리베이스 중. wine32on64 형태로 나오면 이 레포 스크립트로 즉시 적용, 벽1·2 해결분과 합쳐 완주 가능성. (가장 저비용)
+1. **CrossOver 26.3 GPL 소스로 wine32on64 직접 빌드**: 소스는 공개(`media.codeweavers.com/pub/crossover/source/crossover-sources-26.3.0.tar.gz`, 142MB, wine에 win32on64 지원 확인). 단, CrossOver의 빌드 오케스트레이션은 비공개라 빌드 과정을 재구성해야 함(대형 작업, Gcenx/Sikarugir 수준). D3DMetal(Apple GPTK, 소스 미포함)은 설치된 CrossOver에서 이식 가능(그래픽은 이미 검증됨).
+2. **커뮤니티 CX26 wine32on64 빌드 대기**: @dappermint가 CX26.3을 이미 리베이스 중. wine32on64 형태로 나오면 이 레포 스크립트로 즉시 적용, 벽1·2 해결분과 합쳐 완주 가능성. (가장 저비용)
 3. CrossOver 구매.
 
 ## 이미 확보한 자산 (완주에 재사용)
@@ -39,25 +39,25 @@ D2R 완주에 필요한 것 = **CrossOver 26급 wine32on64**(구식 32-on-64 + �
 
 **정지에 무관했던 시도(전부 86MB 동일)**: wine-mono 10.4.1 이식, CrossOver entitlement 서명, CrossOver 보틀 사용, DXMT(winemetal) 이식, msync/esync/fsync off, 배틀넷 세션 살린 상태의 -uid osi 실행.
 
-**해석**: 차이는 CrossOver 바이너리에만 있는 부분 — 공개 GPL 소스에 없는 **게임별 프로프라이어터리 처리(CW HACK/DXMT 완본)** 또는 Rosetta2-안티치트 상호작용의 빌드/서명 세부. CodeWeavers도 이 안티치트+Rosetta 문제로 수개월 고생(Apple 26.4 Rosetta 수정 필요)했던 바로 그 지점.
+**해석**: 차이는 CrossOver 바이너리에만 있는 부분. 공개 GPL 소스에 없는 **게임별 프로프라이어터리 처리(CW HACK/DXMT 완본)** 또는 Rosetta2-안티치트 상호작용의 빌드/서명 세부. CodeWeavers도 이 안티치트+Rosetta 문제로 수개월 고생(Apple 26.4 Rosetta 수정 필요)했던 바로 그 지점.
 
 **다음 후보**: (a) 우리 빌드 D2R vs CrossOver D2R를 동일 시점 sample 비교해 분기점 격리, (b) DXMT 완전본(d3d12 경로 포함) 확보, (c) 커뮤니티 CX26 wine32on64 빌드(@dappermint) 대기. 엔진은 재사용 준비 완료.
 
 ## ✅ 최종 해결 (2026-08-27)
 
-위 "해석"은 틀렸다 — CrossOver 바이너리만의 비밀이 아니라 **실행 환경 변수**였다.
+위 "해석"은 틀렸다. CrossOver 바이너리만의 비밀이 아니라 **실행 환경 변수**였다.
 
-**`ROSETTA_ADVERTISE_AVX=1`** — CrossOver의 `bin/wine` perl 래퍼가 조용히 설정하는 값. D2R 로더는 AVX 명령어 지원을 요구하며, Rosetta 2는 이 변수가 있어야 AVX를 CPUID에 광고한다. 이것 없이는 로더가 86MB/0%CPU로 영원히 대기한다(위에서 관찰한 그 정지).
+**`ROSETTA_ADVERTISE_AVX=1`**: CrossOver의 `bin/wine` perl 래퍼가 조용히 설정하는 값. D2R 로더는 AVX 명령어 지원을 요구하며, Rosetta 2는 이 변수가 있어야 AVX를 CPUID에 광고한다. 이것 없이는 로더가 86MB/0%CPU로 영원히 대기한다(위에서 관찰한 그 정지).
 
 이후 그래픽은 D3DMetal 심링크 레이아웃(lib/external 실물 + x86_64-unix 심링크, 복사 금지)과 GPTK PE dll(d3d11/d3d12/dxgi) + `CX_ACTIVE_GRAPHICS_BACKEND=d3dmetal`로 해결. 자체 빌드 wine 11.0(신형 WoW64)에서 **D2R 인게임 렌더링 확인** (메모리 2.7GB, CPU 175%, D3DMetal 로그).
 
-전체 실행 조합은 `scripts/play.sh` 참고. wine32on64가 필요하다던 중간 결론도 폐기 — 신형 WoW64로도 CEF·게임 모두 동작한다(벽1의 진짜 원인은 엔진 계열이 아니라 조합 문제였음).
+전체 실행 조합은 `scripts/play.sh` 참고. wine32on64가 필요하다던 중간 결론도 폐기. 신형 WoW64로도 CEF·게임 모두 동작한다(벽1의 진짜 원인은 엔진 계열이 아니라 조합 문제였음).
 
 ## 추가 발견 (2026-08-27): libd3dshared는 그래픽이 아니라 '로더 통과'에 필요하다
 
 순수 vkd3d(D3D12→Vulkan→MoltenVK) 경로 실험 결과:
 
-- `ROSETTA_ADVERTISE_AVX=1`만으로는 부족 — libd3dshared 없이는 여전히 86MB 정지.
+- `ROSETTA_ADVERTISE_AVX=1`만으로는 부족: libd3dshared 없이는 여전히 86MB 정지.
 - `CX_APPLEGPTK_LIBD3DSHARED_PATH`를 지정하면(ntdll의 `init_non_native_support`가 dlopen하여 `register_non_native_code_region`을 확보) **D3DMetal 그래픽 없이 vkd3d만으로도 게임이 완주**한다 (2.7GB/CPU 600%+, MoltenVK 렌더링).
 
 **결론: D2R 로더(안티치트)의 Rosetta 통과 조건 = AVX 광고 + GPTK의 비네이티브 코드영역 등록, 두 가지 모두.** libd3dshared는 이 후자를 제공하는 유일한 공급원이므로, GPTK(또는 CrossOver)에서 이 파일 하나는 반드시 조달해야 한다. 그래픽 백엔드는 vkd3d(완전 오픈소스)로 대체 가능.

--- a/docs/DIAGNOSIS.md
+++ b/docs/DIAGNOSIS.md
@@ -2,7 +2,7 @@
 
 macOS(Apple Silicon)에서 무료 Wine으로 Battle.net을 돌릴 때의 두 개의 벽과 그 원인.
 
-## 벽 1 — CEF 로그인 웹뷰 렌더러 크래시 (해결됨)
+## 벽 1: CEF 로그인 웹뷰 렌더러 크래시 (해결됨)
 
 ### 증상
 로그인 창이 검은 화면 + 스피너만. 렌더러가 5초마다 재시작:
@@ -26,9 +26,9 @@ stock Whisky / frankea 엔진(v3.1.1, v4.5beta, v2.5.0)은 전부 **신형 WoW64
 - 번들에 dylib이 없음 → Whisky 엔진의 `Wine/lib/*.dylib`를 번들 `bin/`에 복사 + `install_name_tool -add_rpath @loader_path/` + adhoc 재서명. MoltenVK는 `lib/wine/x86_64-unix/`에도 복사.
 - 유저 `AppData/Roaming/Battle.net`(Battle.net.config) 존재해야 로그인 URL 로드됨.
 - `--disable-gpu-compositing`로 실행 (소프트웨어 합성).
-- GL 에러(`SharedImageStub`, `Failed to create ... context for virtualization`)는 **무해** — 진짜 CrossOver도 동일하게 99개씩 냄.
+- GL 에러(`SharedImageStub`, `Failed to create ... context for virtualization`)는 **무해**. 진짜 CrossOver도 동일하게 99개씩 냄.
 
-## 벽 1 — 진짜 원인 확정: `WINE_SIMULATE_WRITECOPY` (2026-08-29)
+## 벽 1, 진짜 원인 확정: `WINE_SIMULATE_WRITECOPY` (2026-08-29)
 
 위 "신형 WoW64" 설명은 결과적으로 맞는 엔진을 고르게 했지만 원인은 아니었다. CrossOver 26.3 GPL 소스로
 직접 빌드한 엔진(`cx26-engine`)에서도 같은 int3(`libcef.dll+0x16D00E1`)가 재현됐고, CX 출하 바이너리의
@@ -60,10 +60,10 @@ stock Whisky / frankea 엔진(v3.1.1, v4.5beta, v2.5.0)은 전부 **신형 WoW64
 해결: 모든 실행 경로(`install.sh`, `scripts/play.sh`, `scripts/create-bottle.sh`)에 `WINE_SIMULATE_WRITECOPY=1`.
 CrossOver 바이너리 의존 0.
 
-## 벽 1-b — CX 의존 #2: 투명한 메인창 (`--in-process-gpu --use-gl=swiftshader`) (2026-08-29)
+## 벽 1-b, CX 의존 #2: 투명한 메인창 (`--in-process-gpu --use-gl=swiftshader`) (2026-08-29)
 
 `WINE_SIMULATE_WRITECOPY=1`만으로는 렌더러는 살지만 **Dock 아이콘만 뜨고 창이 안 보인다**. `CGWindowListCopyWindowInfo`로
-보면 1600×1000 창이 화면 정중앙에 "존재"(alpha 1)하지만 내용이 없다 — Battle.net 메인창은 frameless라 내용이 안 그려지면
+보면 1600×1000 창이 화면 정중앙에 "존재"(alpha 1)하지만 내용이 없다. Battle.net 메인창은 frameless라 내용이 안 그려지면
 완전히 투명하다. libcef 로그 비교:
 
 - CX ntdll: GPU 프로세스 없음(NtCreateUserProcess `--type=gpu-process` 0건), 브라우저 프로세스 안에서 GLES 컨텍스트 생성.
@@ -73,25 +73,25 @@ CrossOver 바이너리 의존 0.
 원인: A에서 Battle.net.exe가 받는 인자가 `--disable-gpu-compositing --from-launcher --in-process-gpu --use-gl=swiftshader`.
 `Battle.net Launcher.exe`는 양쪽 다 앞의 두 개만 넘기고(`+relay`로 확인), 뒤의 두 개는 **CX ntdll.so의 NtCreateUserProcess
 내부에서 주입**된다. 출처는 CodeWeavers의 비공개·암호화 호환 DB(`~/Library/Application Support/CrossOver/compatdb-26.dat`,
-`cxcompatdb.so`)의 앱별 규칙 — GPL 소스에도, 바이너리 문자열에도 없다.
+`cxcompatdb.so`)의 앱별 규칙. GPL 소스에도, 바이너리 문자열에도 없다.
 
 해결: Launcher.exe를 거치지 않고 `Battle.net.exe --disable-gpu-compositing --from-launcher --in-process-gpu --use-gl=swiftshader`를
 직접 실행 (`install.sh` 런처, `scripts/play.sh`). 검증: GPU 프로세스 0, GLES 컨텍스트 생성, 렌더러 6, 로그인·메인창, **화면 표시·게임 실행 사용자 확인**.
 
-## Epic Games Launcher — 같은 엔진에서 추가 조치 없이 동작 (2026-08-29)
+## Epic Games Launcher: 같은 엔진에서 추가 조치 없이 동작 (2026-08-29)
 
 벽 1/1-b가 배틀넷 고유 문제인지 CEF 일반 문제인지 확인하려고 Epic Games Launcher(UE5 + CEF3 `EpicWebHelper.exe`, Chrome/90)를 같은 엔진·같은 env(`WINE_SIMULATE_WRITECOPY=1` 포함)로 돌렸다.
 
 - 설치: 공식 `EpicGamesLauncherInstaller.msi`를 `msiexec /i … /qn`으로 무인 설치, 26초. 메뉴빌더 에러(`cx_wineshelllink`)만 나고 무해.
-- 실행: `EpicGamesLauncher.exe` 기본 인자 그대로. CEF가 `--type=gpu-process`를 별도 프로세스로 띄우는데 **죽지 않는다** — 배틀넷과 달리 `--in-process-gpu --use-gl=swiftshader`가 필요 없었다. 1826×857 메인창, 로그인, 스토어 UI 렌더링 확인.
+- 실행: `EpicGamesLauncher.exe` 기본 인자 그대로. CEF가 `--type=gpu-process`를 별도 프로세스로 띄우는데 **죽지 않는다**. 배틀넷과 달리 `--in-process-gpu --use-gl=swiftshader`가 필요 없었다. 1826×857 메인창, 로그인, 스토어 UI 렌더링 확인.
 - wined3d는 `Using the Vulkan renderer for d3d10/11`(MoltenVK) 경로를 탔다. 런처 UI 자체는 이걸로 충분.
 - 로그의 `LogDPoP: Failed to create persistent DPoP key (0x80090029)`는 Linux Wine에서도 나오는 것으로 로그인에 영향 없음.
-- 트레이 UX: 창 닫기 = 숨김(Windows와 동일). Epic이 `Shell_NotifyIcon`으로 등록한 트레이 아이콘을 winemac systray가 **macOS 메뉴바 NSStatusItem**으로 올리고(`+systray` 트레이스로 확인), **우클릭** 메뉴로 창 열기·Exit가 된다 — 사용자 검증 완료. 좌클릭은 WM_LBUTTONDOWN/UP+NIN_SELECT까지 정상 전달되지만 Epic이 반응하지 않는다(Windows에서도 메뉴 기반). 시도했다 버린 것들: exe 재실행·`com.epicgames.launcher://` URL은 실행 중 인스턴스가 무시; 외부에서 `ShowWindow(SW_SHOW/RESTORE)`로 숨긴 창을 띄우면 보이긴 하지만 Slate가 "최소화" 상태를 유지해 **입력을 안 받는 먹통 창**이 된다. 그래서 Epic 모드는 `WINE_DOCK_REOPEN_CMD`를 쓰지 않는다.
+- 트레이 UX: 창 닫기 = 숨김(Windows와 동일). Epic이 `Shell_NotifyIcon`으로 등록한 트레이 아이콘을 winemac systray가 **macOS 메뉴바 NSStatusItem**으로 올리고(`+systray` 트레이스로 확인), **우클릭** 메뉴로 창 열기·Exit가 된다, 사용자 검증 완료. 좌클릭은 WM_LBUTTONDOWN/UP+NIN_SELECT까지 정상 전달되지만 Epic이 반응하지 않는다(Windows에서도 메뉴 기반). 시도했다 버린 것들: exe 재실행·`com.epicgames.launcher://` URL은 실행 중 인스턴스가 무시; 외부에서 `ShowWindow(SW_SHOW/RESTORE)`로 숨긴 창을 띄우면 보이긴 하지만 Slate가 "최소화" 상태를 유지해 **입력을 안 받는 먹통 창**이 된다. 그래서 Epic 모드는 `WINE_DOCK_REOPEN_CMD`를 쓰지 않는다.
 - 부수 수정: `WINE_DOCK_REOPEN_CMD` 훅의 "보이는 창" 판정이 Epic의 화면 밖(-10000,-10000) 1×1 투명 보조창을 보이는 창으로 세던 것을 실제 화면 안·alpha>0·크기>1 조건으로 고쳤고, `build-engine.sh`가 CX 엔진에도 winemac 패치를 적용한다.
 
 결론: 벽 1(`WRITECOPY`)은 libcef 버전에 따라 걸리는 일반 문제일 수 있지만, 벽 1-b(GPU 프로세스 사망)는 Battle.net의 CEF 빌드/설정 고유. 다른 CEF 런처(GOG Galaxy·EA app·Ubisoft Connect)도 같은 절차로 먼저 "그냥 돌려보는" 것이 맞다.
 
-## 벽 2 — Battle.net Agent caller 서명 검증 실패 (해결됨)
+## 벽 2: Battle.net Agent caller 서명 검증 실패 (해결됨)
 
 ### 증상
 로그인 성공 후: `Oops! An error occurred while loading game information ... BLZBNTBNA00000005`.

--- a/docs/STEAM-GAMES.md
+++ b/docs/STEAM-GAMES.md
@@ -1,4 +1,4 @@
-# Steam + D3D11 games on Apple Silicon — the full free path
+# Steam + D3D11 games on Apple Silicon: the full free path
 
 Verified 2026-08-27 on M4 Pro / macOS 26.5: Windows Steam client (Aug 2026 build,
 CEF 126) renders and authenticates, and a Unity D3D11 title launched from the
@@ -27,20 +27,20 @@ Two D3D11 implementations must coexist in one prefix:
 Hard-won facts, in the order they burned us:
 
 1. **DXMT dlls must be builtins.** Loaded as native they cannot attach their
-   unixlib (`winemetal.so`) — wine falls back to vanilla silently.
+   unixlib (`winemetal.so`). Wine falls back to vanilla silently.
 2. **Wine-built PEs dropped into a game folder are treated as fake dlls** and
-   silently redirected to the bundle builtin — game-local DXMT does not work.
+   silently redirected to the bundle builtin. Game-local DXMT does not work.
 3. **A builtin that isn't part of wine needs a placeholder**: without a
    `winemetal.dll` copy in `system32`, by-name lookup fails with `c0000135`
    ("Failed to initialize graphics" in Unity) even though the builtin exists.
 4. **The Steam client dies on DXMT builtins** (helper restart loop every 10 s),
    so it must be forced to vanilla per-app. But per-app `native` pointing at a
-   vanilla wine PE gets redirected to the (DXMT) builtin — unless you strip the
+   vanilla wine PE gets redirected to the (DXMT) builtin, unless you strip the
    `Wine builtin DLL` marker from the copies (1-byte patch).
 5. **i386 stays vanilla.** steam.exe is 32-bit; its composer must not see DXMT.
 6. **`winemac.so` must export macdrv symbols** (`-fvisibility=default` rebuild)
    or DXMT's `_CreateMetalViewFromHWND` cannot dlsym them.
-7. **Env `WINEDLLOVERRIDES` beats per-app registry** — keep d3d overrides out of
+7. **Env `WINEDLLOVERRIDES` beats per-app registry**: keep d3d overrides out of
    the env; drive the split from the registry only.
 8. **Steam tags games with `DISABLEDXMAXIMIZEDWINDOWEDMODE`**, forcing
    fullscreen; scrub it from `user.reg` for windowed play. Unity then remembers
@@ -50,7 +50,7 @@ Hard-won facts, in the order they burned us:
 10. **One Dock icon**: macdrv registers a Dock icon per wine process with
    windows, and this macdrv ignores virtual desktops. We patched
    `cocoa_app.m` (modeled on CrossOver's hack 24141) to honor
-   `WINE_NO_DOCK_ICON="steam.exe;steamservice.exe"` — matching the basename of
+   `WINE_NO_DOCK_ICON="steam.exe;steamservice.exe"`, matching the basename of
    the first two argv entries (NSProcessInfo sees pre-rewrite argv; scanning all
    args would also hide the helper via its `-steampath=` argument).
 
@@ -64,7 +64,7 @@ three fixes we needed on macOS 26.5 / current Homebrew:
 - `src/util/com/com_guid.cpp` needs `#include <iomanip>` (newer mingw).
 - The prebuilt LLVM 15 x86_64 tree references zstd: build an x86_64
   `libzstd.a` and `libtool -static`-merge it into `libLLVMSupport.a`.
-- The 3Shain wine toolchain tarball extracts flat — normalise into
+- The 3Shain wine toolchain tarball extracts flat. Normalise into
   `toolchains/wine/`.
 - The Dock-icon patch on top of the visibility rebuild lives in
   `transformProcessToForeground:` (see `scripts/setup-steam-games.sh` header).
@@ -73,7 +73,7 @@ DXMT is LGPL-2.1+ (Copyright Feifan He for CodeWeavers); the wrapper is MIT
 (vendored in `third_party/`); our winemac patch is published as
 `patches/winemac-no-dock-icon.patch` (LGPL-2.1+, matching Wine). The same patch adds
 `WINE_DOCK_REOPEN_CMD`: when the Dock icon is clicked and no Wine window is visible, winemac runs
-the command — `play.sh steam` sets it to `steam.exe steam://open/main`, so closing the Steam window
+the command, `play.sh steam` sets it to `steam.exe steam://open/main`, so closing the Steam window
 parks it (as on Windows) and a Dock click brings it back; Steam > Exit really quits. Nothing
 proprietary is redistributed.
 

--- a/docs/guides/diablo-2-resurrected-apple-silicon.html
+++ b/docs/guides/diablo-2-resurrected-apple-silicon.html
@@ -4,9 +4,9 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>How to play Diablo II: Resurrected on Apple Silicon Macs (free, 2026)</title>
-<meta name="description" content="D2R hangs at launch on M1/M2/M3/M4 Macs because of an AVX detection quirk in Rosetta 2. Here is the root cause and a fully free, open-source way to play — no CrossOver needed.">
+<meta name="description" content="D2R hangs at launch on M1/M2/M3/M4 Macs because of an AVX detection quirk in Rosetta 2. Here is the root cause and a fully free, open-source way to play. No CrossOver needed.">
 <link rel="canonical" href="https://bcd1210.github.io/soju/guides/diablo-2-resurrected-apple-silicon.html">
-<meta property="og:title" content="Diablo II: Resurrected on Apple Silicon — the fix and a free setup">
+<meta property="og:title" content="Diablo II: Resurrected on Apple Silicon: the fix and a free setup">
 <meta property="og:description" content="The real reason D2R hangs on M-series Macs, and a free open-source Wine setup that runs it.">
 <meta property="og:type" content="article">
 <link rel="stylesheet" href="../style.css">
@@ -41,7 +41,7 @@ walls. Each has a real, specific cause:</p>
 AVX, but only <em>advertises</em> it to a process when the undocumented
 environment variable <code>ROSETTA_ADVERTISE_AVX=1</code> is set. Without it the
 loader waits forever before graphics initialization. This single variable is why
-CrossOver works while most free wrappers appear broken — CrossOver sets it in its
+CrossOver works while most free wrappers appear broken: CrossOver sets it in its
 launcher.</p>
 
 <h3>2. Battle.net shows "BLZBNTBNA00000005" (the "Oops" page)</h3>
@@ -53,18 +53,18 @@ CrossOver sources, which do.</p>
 
 <h3>3. Graphics crash loops with D3DMetal</h3>
 <p>Apple's Game Porting Toolkit libraries must live in <code>lib/external/</code>
-with the wine <code>.so</code> files as <em>symlinks</em> into it — copying the
+with the wine <code>.so</code> files as <em>symlinks</em> into it. Copying the
 files breaks <code>@loader_path</code> resolution and D3DMetal dies in an
 assertion loop. <code>libd3dshared</code> is also required for the loader to pass
 Rosetta at all (it registers non-native code regions), not just for graphics.</p>
 
 <div class="note">All of this is documented in depth, with logs, in the
 <a href="https://github.com/BCD1210/soju/blob/main/docs/DIAGNOSIS.md">diagnosis writeup</a>
-— useful even if you use a different Wine frontend.</div>
+(useful even if you use a different Wine frontend).</div>
 
 <h2>Requirements</h2>
 <ul>
-  <li>Apple Silicon Mac (M1 or newer) — verified on M4 Pro</li>
+  <li>Apple Silicon Mac (M1 or newer), verified on M4 Pro</li>
   <li><strong>macOS 26.4 or newer recommended</strong>: a 2026 Blizzard anti-cheat
   update triggered a Rosetta 2 bug that Apple fixed in 26.4. On older macOS the
   game can stall even with everything else correct.</li>
@@ -77,9 +77,9 @@ Rosetta at all (it registers non-native code regions), not just for graphics.</p
 <ol>
   <li><strong>Install:</strong> <code>brew install BCD1210/soju/soju</code> (or the
   <a href="https://github.com/BCD1210/soju#install-one-line">one-line installer</a>)</li>
-  <li><strong>Run</strong> <code>soju install</code> — it downloads the engine
+  <li><strong>Run</strong> <code>soju install</code>. It downloads the engine
   (~350MB), then asks you to download Apple's Game Porting Toolkit dmg and press
-  Enter. It then installs Battle.net automatically (5–10 minutes).</li>
+  Enter. It then installs Battle.net automatically (5-10 minutes).</li>
   <li><strong>Play:</strong> double-click <code>~/Applications/Battle.net.app</code>
   (or run <code>soju battlenet</code>), log in, install D2R inside the app, press
   Play. For offline sessions afterwards: <code>soju d2r</code>.</li>
@@ -89,11 +89,11 @@ Rosetta at all (it registers non-native code regions), not just for graphics.</p
 <table>
   <tr><th>Symptom</th><th>Fix</th></tr>
   <tr><td>Game stuck at launch, ~86MB RAM</td>
-      <td>You're not using Soju's launcher — <code>ROSETTA_ADVERTISE_AVX=1</code> is missing. Launch via <code>soju battlenet</code> / <code>soju d2r</code>.</td></tr>
+      <td>You're not using Soju's launcher. <code>ROSETTA_ADVERTISE_AVX=1</code> is missing. Launch via <code>soju battlenet</code> / <code>soju d2r</code>.</td></tr>
   <tr><td>BLZBNTBNA00000005 after login</td>
-      <td>Engine problem — make sure you're on Soju's engine, not a generic wine build.</td></tr>
+      <td>Engine problem. Make sure you're on Soju's engine, not a generic wine build.</td></tr>
   <tr><td>"Failed to initialize graphics"</td>
-      <td>GPTK not installed — run <code>scripts/get-gptk.sh</code>.</td></tr>
+      <td>GPTK not installed. Run <code>scripts/get-gptk.sh</code>.</td></tr>
   <tr><td>Typed text shows as ??</td>
       <td>Switch the macOS input source to English (ABC) while typing in Wine windows.</td></tr>
 </table>
@@ -102,7 +102,7 @@ Rosetta at all (it registers non-native code regions), not just for graphics.</p
 <p>Yes. The engine is compiled from the GPL Wine sources CodeWeavers publishes,
 Apple's Game Porting Toolkit is a free download from Apple (you download it
 yourself; it is never redistributed), and you play on your own Battle.net
-account. Nothing is cracked or emulated — D2R runs against the real Battle.net.</p>
+account. Nothing is cracked or emulated. D2R runs against the real Battle.net.</p>
 
 <p><a class="btn" href="https://github.com/BCD1210/soju">Get Soju on GitHub</a></p>
 </main>

--- a/docs/guides/ko/diablo-2-mac.html
+++ b/docs/guides/ko/diablo-2-mac.html
@@ -3,10 +3,10 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>맥에서 디아블로 II 레저렉션 돌리기 — 무료 방법 (애플 실리콘, 2026)</title>
+<title>맥에서 디아블로 II 레저렉션 돌리기: 무료 방법 (애플 실리콘, 2026)</title>
 <meta name="description" content="M1/M2/M3/M4 맥에서 디아블로2 레저렉션이 실행 안 되는 진짜 이유(AVX)와, 크로스오버 없이 완전 무료로 돌리는 오픈소스 방법. 배틀넷 로그인부터 인게임까지 검증됨.">
 <link rel="canonical" href="https://bcd1210.github.io/soju/guides/ko/diablo-2-mac.html">
-<meta property="og:title" content="맥에서 디아2 레저렉션 — 무료로 돌리는 법">
+<meta property="og:title" content="맥에서 디아2 레저렉션: 무료로 돌리는 법">
 <meta property="og:description" content="애플 실리콘 맥에서 D2R이 멈추는 원인과 무료 해결법">
 <meta property="og:type" content="article">
 <link rel="stylesheet" href="../../style.css">
@@ -45,26 +45,26 @@ soju battlenet    # 로그인 후 앱에서 디아2 설치 → 플레이</code><
 크로스오버 GPL 소스로 빌드해서 이 문제가 없습니다.</p>
 
 <h3>3. 그래픽 크래시 루프</h3>
-<p>애플 게임 포팅 툴킷(GPTK) 라이브러리는 반드시 심링크 구조로 배치해야 합니다 —
+<p>애플 게임 포팅 툴킷(GPTK) 라이브러리는 반드시 심링크 구조로 배치해야 합니다.
 복사하면 <code>@loader_path</code>가 어긋나 어설션 루프로 죽습니다. Soju가 자동으로
 처리합니다.</p>
 
 <h2>준비물</h2>
 <ul>
   <li>애플 실리콘 맥 (M1 이상)</li>
-  <li><strong>macOS 26.4 이상 권장</strong> — 2026년 블리자드 안티치트 업데이트가
+  <li><strong>macOS 26.4 이상 권장</strong>. 2026년 블리자드 안티치트 업데이트가
   로제타 버그를 유발했고, 애플이 26.4에서 수정했습니다</li>
   <li>로제타2: <code>softwareupdate --install-rosetta</code></li>
-  <li>무료 Apple ID (GPTK 1회 다운로드용 — 애플이 재배포를 금지해서 직접 받아야 합니다)</li>
+  <li>무료 Apple ID (GPTK 1회 다운로드용, 애플이 재배포를 금지해서 직접 받아야 합니다)</li>
   <li>본인 배틀넷 계정 + 디아2 레저렉션 소지</li>
 </ul>
 
 <h2>문제 해결</h2>
 <table>
   <tr><th>증상</th><th>해결</th></tr>
-  <tr><td>실행 후 무한 정지 (86MB)</td><td><code>soju battlenet</code>/<code>soju d2r</code>로 실행하세요 — AVX 변수가 빠진 겁니다</td></tr>
+  <tr><td>실행 후 무한 정지 (86MB)</td><td><code>soju battlenet</code>/<code>soju d2r</code>로 실행하세요. AVX 변수가 빠진 겁니다</td></tr>
   <tr><td>BLZBNTBNA00000005</td><td>Soju 엔진인지 확인 (일반 wine 빌드는 안 됩니다)</td></tr>
-  <tr><td>"Failed to initialize graphics"</td><td>GPTK 미설치 — <code>scripts/get-gptk.sh</code> 실행</td></tr>
+  <tr><td>"Failed to initialize graphics"</td><td>GPTK 미설치. <code>scripts/get-gptk.sh</code> 실행</td></tr>
   <tr><td>한글 입력이 ??로 표시</td><td>wine 창에서는 macOS 입력기를 영어(ABC)로 전환</td></tr>
 </table>
 

--- a/docs/guides/steam-windows-client-apple-silicon.html
+++ b/docs/guides/steam-windows-client-apple-silicon.html
@@ -6,7 +6,7 @@
 <title>Run the Windows Steam client on Apple Silicon Macs (free, 2026)</title>
 <meta name="description" content="How to run the Windows Steam client and D3D11 games on M1/M2/M3/M4 Macs for free: wine-stable + a steamwebhelper wrapper + DXMT, with the black-screen and rendering problems actually explained.">
 <link rel="canonical" href="https://bcd1210.github.io/soju/guides/steam-windows-client-apple-silicon.html">
-<meta property="og:title" content="Windows Steam client on Apple Silicon — the working free setup">
+<meta property="og:title" content="Windows Steam client on Apple Silicon: the working free setup">
 <meta property="og:description" content="Steam client login, library and D3D11 in-game rendering on M-series Macs, fully free.">
 <meta property="og:type" content="article">
 <link rel="stylesheet" href="../style.css">
@@ -20,7 +20,7 @@
 </div></nav>
 <main>
 <h1>The Windows Steam client on Apple Silicon</h1>
-<p class="lead">Yes, the actual Windows Steam client — not just macOS Steam — runs
+<p class="lead">Yes, the actual Windows Steam client (not just macOS Steam) runs
 on M-series Macs for free, including D3D11 games rendering in-game. Verified on an
 M4 Pro / macOS 26 with the August 2026 Steam client.</p>
 
@@ -48,7 +48,7 @@ break it on macOS Wine:</p>
 steam-on-m1-wine</a>, MIT) is a tiny wrapper around <code>steamwebhelper.exe</code>
 that forces <code>--disable-gpu --single-process</code>, plus launching Steam with
 <code>-no-cef-sandbox -cef-single-process</code>. Soju builds and redeploys the
-wrapper automatically — Steam updates keep restoring the original, so this must
+wrapper automatically. Steam updates keep restoring the original, so this must
 happen on every launch.</p>
 
 <h2>Making games actually render (DXMT)</h2>
@@ -60,14 +60,14 @@ need <a href="https://github.com/3Shain/dxmt">DXMT</a> (D3D11→Metal). Soju's
   <li>DXMT installed as 64-bit Wine <em>builtins</em> (as natives they can't attach
   their Metal unixlib)</li>
   <li>A <code>winemetal.dll</code> placeholder in <code>system32</code> (without it,
-  by-name lookup fails with <code>c0000135</code> — Unity's "Failed to initialize
+  by-name lookup fails with <code>c0000135</code>. Unity's "Failed to initialize
   graphics")</li>
   <li>Marker-stripped vanilla d3d DLLs served to the Steam client per-app via the
   registry (a 1-byte patch defeats Wine's fake-DLL redirect)</li>
   <li>A rebuilt <code>winemac.so</code> exporting macdrv symbols so DXMT can present,
   plus a <code>WINE_NO_DOCK_ICON</code> patch for a single Dock icon</li>
 </ul>
-<p>The full story — ten hard-won facts, each one a wall we hit — is in
+<p>The full story (ten hard-won facts, each one a wall we hit) is in
 <a href="https://github.com/BCD1210/soju/blob/main/docs/STEAM-GAMES.md">docs/STEAM-GAMES.md</a>.</p>
 
 <h2>Practical notes</h2>
@@ -76,7 +76,7 @@ need <a href="https://github.com/3Shain/dxmt">DXMT</a> (D3D11→Metal). Soju's
   <tr><td>Black window on launch</td>
       <td>A crashed session leaves a <code>SingletonLock</code>; <code>soju steam</code> cleans it automatically. If launching manually, delete it from htmlcache.</td></tr>
   <tr><td>Steam shows a "not responding" dialog while updating</td>
-      <td>Normal on first run — let it finish.</td></tr>
+      <td>Normal on first run. Let it finish.</td></tr>
   <tr><td>Typed text appears as ??</td>
       <td>Switch macOS input to English (ABC).</td></tr>
   <tr><td>Game forces fullscreen</td>

--- a/docs/guides/whisky-alternative.html
+++ b/docs/guides/whisky-alternative.html
@@ -3,10 +3,10 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Whisky is discontinued — free alternatives for Mac gaming (2026)</title>
-<meta name="description" content="Whisky, the free Wine GUI for macOS, is no longer maintained and its CDN is offline. Here are the options left in 2026 — paid (CrossOver) and free (Soju, Kegworks, PlayOnMac) — compared honestly.">
+<title>Whisky is discontinued: free alternatives for Mac gaming (2026)</title>
+<meta name="description" content="Whisky, the free Wine GUI for macOS, is no longer maintained and its CDN is offline. Here are the options left in 2026: paid (CrossOver) and free (Soju, Kegworks, PlayOnMac), compared honestly.">
 <link rel="canonical" href="https://bcd1210.github.io/soju/guides/whisky-alternative.html">
-<meta property="og:title" content="Whisky alternatives in 2026 — what's left for Mac gaming">
+<meta property="og:title" content="Whisky alternatives in 2026: what's left for Mac gaming">
 <meta property="og:description" content="An honest comparison of the free and paid ways to run Windows games on Apple Silicon after Whisky's discontinuation.">
 <meta property="og:type" content="article">
 <link rel="stylesheet" href="../style.css">
@@ -21,8 +21,8 @@
 <main>
 <h1>Whisky is gone. What now?</h1>
 <p class="lead">Whisky was the free way to run Windows games on Apple Silicon.
-Development stopped, and its content server (data.getwhisky.app) went offline —
-fresh installs can't even complete first-time setup anymore. Here's an honest map
+Development stopped, and its content server (data.getwhisky.app) went offline.
+Fresh installs can't even complete first-time setup anymore. Here's an honest map
 of what's left in 2026.</p>
 
 <h2>The options</h2>
@@ -44,14 +44,14 @@ of what's left in 2026.</p>
 </table>
 
 <h2>Why "just use a Whisky fork" often fails</h2>
-<p>Whisky's problem was never just maintenance — it's that modern launchers need
+<p>Whisky's problem was never just maintenance. It's that modern launchers need
 engine-level work:</p>
 <ul>
   <li><strong>Battle.net</strong> dies with <code>BLZBNTBNA00000005</code> on most free
   engines, because its Agent verifies the connecting process's signature via a
   PID→path lookup that needs macOS-specific Wine code.</li>
   <li><strong>D2R</strong> hangs at launch unless <code>ROSETTA_ADVERTISE_AVX=1</code>
-  is set — an undocumented Rosetta 2 variable.</li>
+  is set, an undocumented Rosetta 2 variable.</li>
   <li><strong>Steam's</strong> modern CEF UI doesn't render on many builds (black
   screen) without a webhelper workaround.</li>
 </ul>
@@ -70,7 +70,7 @@ Windows Steam client on M-series Macs</a>.</p>
 <h2>An honest caveat</h2>
 <p>Soju is young and CLI-based. It verifies specific targets end-to-end rather
 than promising everything will work. If you want a GUI and broad catalog support
-with commercial backing, CrossOver remains the safe choice — Soju is for people
+with commercial backing, CrossOver remains the safe choice. Soju is for people
 who want the free, transparent path and don't mind a terminal.</p>
 
 <p><a class="btn" href="https://github.com/BCD1210/soju">Get Soju on GitHub</a></p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,10 +3,10 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Soju — Free Battle.net, Steam &amp; Epic launchers that actually log in on Apple Silicon</title>
-<meta name="description" content="Soju is a free, open-source (GPL) Wine stack where Battle.net, Steam and the Epic Games Launcher actually log in on Apple Silicon Macs — no black login window, no CrossOver license. Diablo II: Resurrected and D3D11 Steam games verified.">
+<title>Soju: Free Battle.net, Steam &amp; Epic launchers that actually log in on Apple Silicon</title>
+<meta name="description" content="Soju is a free, open-source (GPL) Wine stack where Battle.net, Steam and the Epic Games Launcher actually log in on Apple Silicon Macs. No black login window, no CrossOver license. Diablo II: Resurrected and D3D11 Steam games verified.">
 <link rel="canonical" href="https://bcd1210.github.io/soju/">
-<meta property="og:title" content="Soju — free Windows gaming on Apple Silicon">
+<meta property="og:title" content="Soju: free Windows gaming on Apple Silicon">
 <meta property="og:description" content="Battle.net, Steam and Epic Games Launcher logins that work on M-series Macs, fully free and open source.">
 <meta property="og:type" content="website">
 <link rel="stylesheet" href="style.css">
@@ -22,7 +22,7 @@
 <main>
 <h1>Free Windows gaming on Apple Silicon</h1>
 <p class="lead">Soju is a free, open-source (GPL-3.0) toolchain that runs Battle.net,
-Diablo&nbsp;II: Resurrected and the Windows Steam client — including D3D11 games —
+Diablo&nbsp;II: Resurrected and the Windows Steam client (including D3D11 games)
 on M-series Macs. No CrossOver license needed.</p>
 
 <pre><code>brew install BCD1210/soju/soju
@@ -43,7 +43,7 @@ soju steam-install</code></pre>
     <p>Get the Steam client and D3D11 games rendering with wine-stable + DXMT.</p>
   </a>
   <a class="card" href="guides/whisky-alternative.html">
-    <h3>Whisky was discontinued — what now?</h3>
+    <h3>Whisky was discontinued: what now?</h3>
     <p>An honest comparison of the free and paid options left in 2026.</p>
   </a>
   <a class="card" href="guides/ko/diablo-2-mac.html">
@@ -68,10 +68,10 @@ soju steam-install</code></pre>
 (the same code CrossOver ships), graphics come from Apple's free
 <a href="https://developer.apple.com/games/game-porting-toolkit/">Game Porting Toolkit</a>,
 and Steam rendering uses <a href="https://github.com/3Shain/dxmt">DXMT</a> (LGPL).
-Nothing proprietary is redistributed — the one Apple file you need is downloaded
+Nothing proprietary is redistributed. The one Apple file you need is downloaded
 from Apple directly, once.</p>
 
-<h2>Not just scripts — root causes</h2>
+<h2>Not just scripts: root causes</h2>
 <p>Every fix in Soju is documented with its underlying cause, so other Wine
 projects can reuse them: the <code>ROSETTA_ADVERTISE_AVX</code> discovery behind the
 famous D2R launch hang, Battle.net Agent's process-signature verification, and the

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Soju one-line installer — Battle.net + Diablo II: Resurrected on Apple Silicon, no CrossOver.
+# Soju one-line installer: Battle.net + Diablo II: Resurrected on Apple Silicon, no CrossOver.
 #   curl -fsSL https://raw.githubusercontent.com/BCD1210/soju/main/install.sh | bash
 #
 # What it does:
@@ -28,7 +28,7 @@ if [ -x "$ENGINE/bin/wine" ]; then
 else
   say "[1/4] Downloading prebuilt engine (~350MB, GPL - built from CodeWeavers' published Wine sources)"
   # The engine ships on its own "engine-*" release, which is not necessarily the
-  # newest release — scan all releases and take the first (newest) engine asset.
+  # newest release: scan all releases and take the first (newest) engine asset.
   URL=$(curl -fsSL "https://api.github.com/repos/$REPO/releases?per_page=30" \
         | grep -o '"browser_download_url": *"[^"]*soju-engine[^"]*"' | head -1 | grep -o 'https[^"]*')
   [ -n "$URL" ] || { echo "Could not find the engine release asset."; exit 1; }

--- a/scripts/build-engine.sh
+++ b/scripts/build-engine.sh
@@ -2,10 +2,10 @@
 # Build the wine 11.0 engine from CrossOver 26.3's published GPL sources (free and legal).
 # Verified: each step of this recipe was verified individually during the real
 # 2026-08 build (Battle.net + D2R in-game). Caveat: a single clean end-to-end
-# re-run is untested — issues welcome.
+# re-run is untested: issues welcome.
 #
 # Requirements: Apple Silicon + Rosetta 2, Xcode CLT, Homebrew (arm64).
-# Run first: scripts/get-components.sh (fetches dylibs+mono — no CrossOver needed)
+# Run first: scripts/get-components.sh (fetches dylibs+mono: no CrossOver needed)
 set -euo pipefail
 
 WORK="${WORK:-$HOME/.battlenet-macos/build}"
@@ -45,7 +45,7 @@ tar -xzf "$WORK/ft.tar.gz" -C "$WORK"
 
 echo "==> Checking the x86_64 dependency dylibs (get-components.sh output)"
 ls "$DEPS/lib/libgnutls.30.dylib" "$DEPS/lib/libMoltenVK.dylib" >/dev/null 2>&1 \
-  || { echo "dylibs missing — run scripts/get-components.sh first"; exit 1; }
+  || { echo "dylibs missing, run scripts/get-components.sh first"; exit 1; }
 
 echo "==> wine configure (x86_64, new-wow64 i386+x86_64)"
 mkdir -p "$WORK/wine-build"; cd "$WORK/wine-build"
@@ -71,7 +71,7 @@ cp -c "$DEPS/lib/"*.dylib "$ENGINE/lib/" 2>/dev/null || true
 # wine-mono 10.4.1 (official release fetched by get-components.sh)
 mkdir -p "$ENGINE/share/wine/mono"
 cp -Rc "$WORK/mono/wine-mono-10.4.1" "$ENGINE/share/wine/mono/" 2>/dev/null \
-  || echo "WARNING: mono missing — check that get-components.sh was run"
+  || echo "WARNING: mono missing, check that get-components.sh was run"
 # rpath + entitlement signing (Rosetta / executable memory)
 cat > "$WORK/ent.plist" <<'PL'
 <?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -95,4 +95,4 @@ echo "Example launch:"
 echo "  export WINEPREFIX=<bottle> CX_GRAPHICS_BACKEND=d3dmetal WINEMSYNC=1 WINE_SIMULATE_WRITECOPY=1"
 echo "  export DYLD_FALLBACK_LIBRARY_PATH='$ENGINE/lib:/usr/lib'"
 echo "  '$ENGINE/bin/wine' 'C:\\\\Program Files (x86)\\\\Battle.net\\\\Battle.net Launcher.exe' --disable-gpu-compositing"
-echo "  (Apple-protected binaries (nohup, ...) in the chain strip DYLD_* — background it with a subshell & instead)"
+echo "  (Apple-protected binaries (nohup, ...) in the chain strip DYLD_*, background it with a subshell & instead)"

--- a/scripts/create-bottle.sh
+++ b/scripts/create-bottle.sh
@@ -11,8 +11,8 @@ export WINEMSYNC=1 ROSETTA_ADVERTISE_AVX=1 WINE_SIMULATE_WRITECOPY=1
 export CX_APPLEGPTK_LIBD3DSHARED_PATH="$ENGINE/lib/external/libd3dshared.dylib"
 export DYLD_FALLBACK_LIBRARY_PATH="$ENGINE/lib:/usr/lib"
 
-[ -x "$ENGINE/bin/wine" ] || { echo "Engine not found — run build-engine.sh first"; exit 1; }
-[ -f "$CX_APPLEGPTK_LIBD3DSHARED_PATH" ] || { echo "libd3dshared not found — run get-gptk.sh first"; exit 1; }
+[ -x "$ENGINE/bin/wine" ] || { echo "Engine not found, run build-engine.sh first"; exit 1; }
+[ -f "$CX_APPLEGPTK_LIBD3DSHARED_PATH" ] || { echo "libd3dshared not found, run get-gptk.sh first"; exit 1; }
 
 WORK="${WORK:-$HOME/.battlenet-macos/build}"; mkdir -p "$WORK"
 
@@ -46,7 +46,7 @@ for i in $(seq 1 60); do
   sleep 10
 done
 BN="$WINEPREFIX/drive_c/Program Files (x86)/Battle.net"
-[ -f "$BN/Battle.net.exe" ] || { echo "Install failed — logs: $WINEPREFIX/drive_c/ProgramData/Battle.net/Setup"; exit 1; }
+[ -f "$BN/Battle.net.exe" ] || { echo "Install failed, logs: $WINEPREFIX/drive_c/ProgramData/Battle.net/Setup"; exit 1; }
 echo "==> Battle.net installed"
 
 "$ENGINE/bin/wineserver" -k 2>/dev/null || true

--- a/scripts/create-epic-bottle.sh
+++ b/scripts/create-epic-bottle.sh
@@ -3,7 +3,7 @@
 # install it with Epic's official MSI.
 # Verified 2026-08-29 (M4 Pro / macOS 26.5): unattended install (~30 s), launcher
 # UI renders, login works. No launcher-specific hacks were needed beyond the
-# Battle.net environment — Epic's CEF (EpicWebHelper) keeps its GPU process
+# Battle.net environment: Epic's CEF (EpicWebHelper) keeps its GPU process
 # alive on this engine, so no --in-process-gpu switch either.
 set -euo pipefail
 
@@ -14,8 +14,8 @@ export WINEMSYNC=1 ROSETTA_ADVERTISE_AVX=1 WINE_SIMULATE_WRITECOPY=1
 export CX_APPLEGPTK_LIBD3DSHARED_PATH="$ENGINE/lib/external/libd3dshared.dylib"
 export DYLD_FALLBACK_LIBRARY_PATH="$ENGINE/lib:/usr/lib"
 
-[ -x "$ENGINE/bin/wine" ] || { echo "Engine not found — run install.sh (or build-engine.sh) first"; exit 1; }
-[ -f "$CX_APPLEGPTK_LIBD3DSHARED_PATH" ] || { echo "libd3dshared not found — run get-gptk.sh first"; exit 1; }
+[ -x "$ENGINE/bin/wine" ] || { echo "Engine not found, run install.sh (or build-engine.sh) first"; exit 1; }
+[ -f "$CX_APPLEGPTK_LIBD3DSHARED_PATH" ] || { echo "libd3dshared not found, run get-gptk.sh first"; exit 1; }
 
 WORK="${WORK:-$HOME/.battlenet-macos/build}"; mkdir -p "$WORK"
 W="$ENGINE/bin/wine"
@@ -35,7 +35,7 @@ echo "==> Running the installer (unattended, about half a minute)"
 "$ENGINE/bin/wineserver" -w
 
 EXE="$WINEPREFIX/drive_c/Program Files/Epic Games/Launcher/Portal/Binaries/Win64/EpicGamesLauncher.exe"
-[ -f "$EXE" ] || { echo "Install failed — try: WINEDEBUG=+msi $W msiexec /i \"$MSI\""; exit 1; }
+[ -f "$EXE" ] || { echo "Install failed, try: WINEDEBUG=+msi $W msiexec /i \"$MSI\""; exit 1; }
 echo "==> Epic Games Launcher installed"
 "$ENGINE/bin/wineserver" -k 2>/dev/null || true
 echo "==> Done. Now run: scripts/play.sh epic   (log in, then install games from the launcher)"

--- a/scripts/create-steam-bottle.sh
+++ b/scripts/create-steam-bottle.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
-# Install Steam (Windows build) — for Steam games such as the Steam edition of
+# Install Steam (Windows build): for Steam games such as the Steam edition of
 # D2R (Infernal Edition).
 #
 # Important: unlike Battle.net, Steam runs on Homebrew wine-stable, not the CX
 # source engine. CX-derived builds cannot render Steam's CEF UI (black screen);
 # the verified free combination is wine-stable 11 + the steamwebhelper wrapper.
-# Wrapper source: github.com/notpop/steam-on-m1-wine (MIT) — source and license
+# Wrapper source: github.com/notpop/steam-on-m1-wine (MIT): source and license
 # vendored in third_party/.
-# Verified 2026-08-27 on M4 Pro / macOS 26.5 — login screen renders.
+# Verified 2026-08-27 on M4 Pro / macOS 26.5: login screen renders.
 set -euo pipefail
 
 export WINEPREFIX="${WINEPREFIX:-$HOME/.battlenet-macos/steam-bottle}"

--- a/scripts/get-components.sh
+++ b/scripts/get-components.sh
@@ -2,7 +2,7 @@
 # Fetch the runtime components without CrossOver:
 #  - x86_64 dylib stack (gnutls/nettle/MoltenVK, ...): from frankea/Whisky's GPL engine release
 #  - wine-mono: from the official wine-mono release
-# (D3DMetal/libd3dshared come from Apple GPTK — see get-gptk.sh)
+# (D3DMetal/libd3dshared come from Apple GPTK: see get-gptk.sh)
 set -euo pipefail
 
 WORK="${WORK:-$HOME/.battlenet-macos/build}"

--- a/scripts/get-gptk.sh
+++ b/scripts/get-gptk.sh
@@ -5,7 +5,7 @@
 # Why it's needed: libd3dshared is required for D2R's loader (anti-cheat) to get
 # through Rosetta 2 (it registers non-native code regions). It also provides the
 # graphics backend (D3DMetal). Apple forbids redistributing it, so you download
-# it yourself — a free Apple ID is enough.
+# it yourself: a free Apple ID is enough.
 #
 # 1) Download the "Game Porting Toolkit" dmg from
 #    https://developer.apple.com/games/game-porting-toolkit/

--- a/scripts/play.sh
+++ b/scripts/play.sh
@@ -1,23 +1,23 @@
 #!/usr/bin/env bash
-# Diablo II: Resurrected — fully free stack launcher (final verified combination)
+# Diablo II: Resurrected: fully free stack launcher (final verified combination)
 #
 # Stack: self-built wine 11.0 (CrossOver 26.3 GPL sources) + D3DMetal (Apple GPTK)
 # Verified 2026-08-27: Battle.net login / Agent / D2R in-game.
 #
 # The three keys (finding these took days):
-#  1) ROSETTA_ADVERTISE_AVX=1   — D2R's loader requires AVX. Without it the game
+#  1) ROSETTA_ADVERTISE_AVX=1: D2R's loader requires AVX. Without it the game
 #     waits forever (stuck at ~86MB RAM).
-#  2) D3DMetal symlink layout   — real files in lib/external, symlinks in
+#  2) D3DMetal symlink layout: real files in lib/external, symlinks in
 #     x86_64-unix. Copying breaks @loader_path and causes an assertion loop
 #     (frankea's README warns about this).
-#  3) Never put Apple-protected binaries (nohup/arch, ...) in the launch chain —
+#  3) Never put Apple-protected binaries (nohup/arch, ...) in the launch chain:
 #     macOS strips DYLD_* when exec'ing them.
 set -euo pipefail
 
 ENGINE="${ENGINE:-$HOME/.battlenet-macos/cx26-engine}"
 MODE="${1:-battlenet}"
 
-# Bottle (virtual C: drive) path — per-mode default (Battle.net and Steam use separate bottles)
+# Bottle (virtual C: drive) path: per-mode default (Battle.net and Steam use separate bottles)
 if [[ "$MODE" == steam* ]]; then
   export WINEPREFIX="${WINEPREFIX:-$HOME/.battlenet-macos/steam-bottle}"
 elif [[ "$MODE" == epic* ]]; then
@@ -53,7 +53,7 @@ REAPER="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/soju-reaper.sh"
 SWEEP="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/soju-sweep.sh"   # orphaned-service cleanup
 start_reaper(){
   # Watchdog: reaps game processes that outlive their windows, and shuts the
-  # prefix down once everything is closed — so "quit" really means quit.
+  # prefix down once everything is closed: so "quit" really means quit.
   pgrep -f "soju-reaper.sh $WINEPREFIX" >/dev/null 2>&1 && return 0
   [ -x "$REAPER" ] && ( "$REAPER" "$WINEPREFIX" "$ENGINE/bin/wineserver" >/dev/null 2>&1 & )
 }
@@ -75,17 +75,17 @@ case "$MODE" in
     cd "$WINEPREFIX/drive_c/Program Files (x86)/Diablo II Resurrected"
     exec "$ENGINE/bin/wine" "D2R.exe" "${@:2}"
     ;;
-  epic)        # Epic Games Launcher — same engine and env as Battle.net (verified 2026-08-29)
+  epic)        # Epic Games Launcher, same engine and env as Battle.net (verified 2026-08-29)
     # Runs as-is: Epic's CEF (EpicWebHelper) keeps its GPU process alive here,
     # so none of the Battle.net command-line switches are needed.
     # Closing the window hides it, exactly like on Windows: Epic's tray icon
     # lands in the macOS menu bar (winemac systray -> NSStatusItem), and its
     # right-click menu reopens the window or exits (left click is ignored by Epic). Do NOT force the hidden window back via
-    # ShowWindow() from outside — Slate keeps its "minimized" state and the
+    # ShowWindow() from outside: Slate keeps its "minimized" state and the
     # window comes back unresponsive.
     EPIC="C:\\Program Files\\Epic Games\\Launcher\\Portal\\Binaries\\Win64\\EpicGamesLauncher.exe"
     [[ -f "$WINEPREFIX/drive_c/Program Files/Epic Games/Launcher/Portal/Binaries/Win64/EpicGamesLauncher.exe" ]] || \
-      { echo "Epic Games Launcher not found — run scripts/create-epic-bottle.sh first"; exit 1; }
+      { echo "Epic Games Launcher not found, run scripts/create-epic-bottle.sh first"; exit 1; }
     pgrep -f "soju-reaper.sh $WINEPREFIX" >/dev/null 2>&1 || \
       { [ -x "$REAPER" ] && ( "$REAPER" "$WINEPREFIX" "$ENGINE/bin/wineserver" epic >/dev/null 2>&1 & ); }
     exec "$ENGINE/bin/wine" "$EPIC" "${@:2}"
@@ -95,7 +95,7 @@ case "$MODE" in
     "$ENGINE/bin/wineserver" -k 2>/dev/null || true
     sleep 2; [ -x "$SWEEP" ] && "$SWEEP"
     ;;
-  steam)       # Steam client — wine-stable + webhelper wrapper (verified 2026-08-27)
+  steam)       # Steam client, wine-stable + webhelper wrapper (verified 2026-08-27)
     # Steam's CEF does not render on the CX engine (black screen / SEGV storm).
     # The verified combination is Homebrew wine-stable 11 + the steamwebhelper
     # wrapper (forces --disable-gpu --single-process) + -no-cef-sandbox
@@ -103,9 +103,9 @@ case "$MODE" in
     # vendored in third_party/.
     WINESTABLE="/Applications/Wine Stable.app/Contents/Resources/wine/bin/wine"
     WINESTABLE_SERVER="/Applications/Wine Stable.app/Contents/Resources/wine/bin/wineserver"
-    [[ -x "$WINESTABLE" ]] || { echo "wine-stable not found — brew install --cask wine-stable"; exit 1; }
+    [[ -x "$WINESTABLE" ]] || { echo "wine-stable not found, brew install --cask wine-stable"; exit 1; }
     ST="$WINEPREFIX/drive_c/Program Files (x86)/Steam/steam.exe"
-    [[ -f "$ST" ]] || { echo "Steam not found — run scripts/create-steam-bottle.sh first"; exit 1; }
+    [[ -f "$ST" ]] || { echo "Steam not found, run scripts/create-steam-bottle.sh first"; exit 1; }
     # 1) Clean crash leftovers (a stale lock makes the next launch a windowless --silent one)
     find "$WINEPREFIX/drive_c/users/"*/AppData/Local/Steam/htmlcache -maxdepth 2 \
       \( -name "Singleton*" -o -name "*.lock" \) -delete 2>/dev/null || true
@@ -123,7 +123,7 @@ case "$MODE" in
     #    prefix. Steam re-adds it on update, so scrub it every launch.
     "$WINESTABLE" reg delete 'HKCU\Software\Microsoft\Windows\CurrentVersion\Run' \
       /v Steam /f >/dev/null 2>&1 || true
-    # 4) Virtual desktop — this macdrv (gcenx wine 11) ignores virtual desktops,
+    # 4) Virtual desktop: this macdrv (gcenx wine 11) ignores virtual desktops,
     #    so it is off by default. The single Dock icon is handled by
     #    WINE_NO_DOCK_ICON (winemac patch) instead.
     #    To enable anyway: WINE_VIRTUAL_DESKTOP=auto (or a resolution like 1600x900).
@@ -140,7 +140,7 @@ case "$MODE" in
     grep -q 'AllowImmovableWindows' "$WINEPREFIX/user.reg" 2>/dev/null || {
       printf '\n[Software\\\\Wine\\\\Mac Driver]\n"AllowImmovableWindows"="n"\n' >> "$WINEPREFIX/user.reg"
     }
-    # 5) Launch — plain wine-stable environment, without the CX engine env
+    # 5) Launch: plain wine-stable environment, without the CX engine env
     STEAM_CMD=("C:\\Program Files (x86)\\Steam\\steam.exe" -no-cef-sandbox -cef-single-process -noverifyfiles "${@:2}")
     [[ -n "$VD" ]] && STEAM_CMD=(explorer.exe "/desktop=soju-steam,$VD" "${STEAM_CMD[@]}")
     # Closing the Steam window parks it in a tray macOS does not show; the patched
@@ -164,7 +164,7 @@ case "$MODE" in
     "$ENGINE/bin/wineserver" -k 2>/dev/null || true
     sleep 2; [ -x "$SWEEP" ] && "$SWEEP"
     ;;
-  steam-kill)  # Stop everything in the Steam bottle — note this bottle runs on
+  steam-kill)  # Stop everything in the Steam bottle, note this bottle runs on
     # wine-stable, so it needs wine-stable's wineserver. Killing the CX engine's
     # wineserver here does nothing and leaves steam.exe alive, which then keeps
     # respawning steamwebhelper (it looks like "Steam relaunches itself").

--- a/scripts/setup-bottle.sh
+++ b/scripts/setup-bottle.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Fully clone an existing CrossOver "Battle.net Desktop App" bottle into a new one.
-# Moving only the game files breaks CEF/Agent — the registries
+# Moving only the game files breaks CEF/Agent: the registries
 # (system/user/userdef) must be cloned along with them.
 # Uses APFS clones (cp -c), so almost no extra disk is used.
 set -euo pipefail

--- a/scripts/setup-steam-games.sh
+++ b/scripts/setup-steam-games.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Enable D3D11 rendering for Steam games — wires DXMT + the patched winemac.
+# Enable D3D11 rendering for Steam games: wires DXMT + the patched winemac.
 #
 # Prerequisites: create-steam-bottle.sh done, and the DXMT artifacts present in
 # ~/.battlenet-macos/steam-support/ (dxmt-x64/{d3d11,dxgi,d3d10core,winemetal}.dll
@@ -15,7 +15,7 @@
 #     "Failed to initialize graphics")
 #   - system32 gets marker-stripped vanilla d3d dlls (native, Steam client only)
 #   - Registry: global d3d11/d3d10core/dxgi/winemetal=builtin (DXMT);
-#     steam.exe / steamwebhelper* / steamservice get per-app native (vanilla) —
+#     steam.exe / steamwebhelper* / steamservice get per-app native (vanilla):
 #     the modern Steam CEF conflicts with DXMT builtins and restart-loops, so the
 #     split is mandatory
 #   - winemac-patched.so: -fvisibility=default (DXMT dlsyms macdrv APIs) +
@@ -29,9 +29,9 @@ WLIB="$WAPP/lib/wine"
 WINE="$WAPP/bin/wine"
 B="$WINEPREFIX/drive_c/windows"
 
-[ -x "$WINE" ] || { echo "wine-stable not found — run create-steam-bottle.sh first"; exit 1; }
+[ -x "$WINE" ] || { echo "wine-stable not found, run create-steam-bottle.sh first"; exit 1; }
 for f in dxmt-x64/d3d11.dll dxmt-x64/dxgi.dll dxmt-x64/d3d10core.dll dxmt-x64/winemetal.dll dxmt-x64/winemetal.so winemac-patched.so; do
-  [ -f "$SUP/$f" ] || { echo "Missing artifact: $SUP/$f — see the build steps in docs/STEAM-GAMES.md"; exit 1; }
+  [ -f "$SUP/$f" ] || { echo "Missing artifact: $SUP/$f, see the build steps in docs/STEAM-GAMES.md"; exit 1; }
 done
 
 echo "==> 1/5 Backing up vanilla dlls (first run only)"
@@ -77,5 +77,5 @@ n = d.replace('DISABLEDXMAXIMIZEDWINDOWEDMODE', '')
 if n != d: open(p, 'w', encoding='utf-8', errors='surrogateescape').write(n)
 EOF
 
-echo "Done. Launch with scripts/play.sh steam — to pin windowed mode, use the"
+echo "Done. Launch with scripts/play.sh steam, to pin windowed mode, use the"
 echo "in-game setting or the Steam launch option '-screen-fullscreen 0' (Unity titles)."

--- a/scripts/soju
+++ b/scripts/soju
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# soju — command-line entry point (used by the Homebrew formula)
+# soju: command-line entry point (used by the Homebrew formula)
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 usage() {
   cat <<'EOF'
-soju — free Battle.net / Diablo II: Resurrected / Epic / Steam on Apple Silicon
+soju: free Battle.net / Diablo II: Resurrected / Epic / Steam on Apple Silicon
 
 Usage:
   soju install        Set up the Wine engine, Apple GPTK and Battle.net

--- a/scripts/soju-reaper.sh
+++ b/scripts/soju-reaper.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# soju-reaper — cleans up game processes that outlive their windows.
+# soju-reaper: cleans up game processes that outlive their windows.
 #
 # Why: under Wine, quitting D2R sometimes leaves D2R.exe alive with no window
 # (a shutdown thread misses a wakeup). The user sees a dead Dock icon and a
@@ -8,7 +8,7 @@
 # idle (no game, no launcher window) it shuts the whole prefix down so nothing
 # lingers after "quit".
 #
-# Window detection uses CGWindowListCopyWindowInfo via python3+ctypes — no
+# Window detection uses CGWindowListCopyWindowInfo via python3+ctypes: no
 # Accessibility permission needed, nothing to install.
 #
 # Usage: soju-reaper.sh <WINEPREFIX> <wineserver-path> [battlenet|steam|epic]

--- a/scripts/soju-sweep.sh
+++ b/scripts/soju-sweep.sh
@@ -1,22 +1,22 @@
 #!/usr/bin/env bash
-# soju-sweep — remove orphaned Wine service processes.
+# soju-sweep: remove orphaned Wine service processes.
 #
 # Every bottle start spawns a set of idle Windows "system" processes
 # (services.exe, winedevice.exe x2, plugplay.exe, rpcss.exe, explorer.exe
-# /desktop — ~100 MB together). When the bottle's wineserver is killed
+# /desktop: ~100 MB together). When the bottle's wineserver is killed
 # (wineserver -k, a crashed launcher, an aborted test) the apps die, but these
 # sleeping services never talk to the server again and so never notice it is
-# gone; they linger for hours. This sweeps them — but ONLY when no wineserver
+# gone; they linger for hours. This sweeps them: but ONLY when no wineserver
 # is running at all, i.e. when nothing in any bottle can still be alive, so a
 # running game or launcher is never touched.
 #
 # Usage: soju-sweep.sh        (called by play.sh *-kill and by soju-reaper.sh)
 set -u
 if pgrep -x wineserver >/dev/null 2>&1 || pgrep -x wineserver64 >/dev/null 2>&1; then
-  exit 0   # something is live — do nothing
+  exit 0   # something is live, do nothing
 fi
 # Also Wine's own prompts (the "Wine Mono Installer" dialog is control.exe
-# appwiz.cpl install_mono) — orphaned, they sit in the Dock as "wine" for hours.
+# appwiz.cpl install_mono): orphaned, they sit in the Dock as "wine" for hours.
 RE='(explorer\.exe /desktop|services\.exe|winedevice\.exe|plugplay\.exe|rpcss\.exe|svchost\.exe|conhost\.exe|tabtip\.exe|control\.exe appwiz\.cpl|wineboot\.exe|winedbg\.exe)'
 PIDS=$(pgrep -f "$RE" 2>/dev/null || true)
 [ -n "$PIDS" ] || exit 0


### PR DESCRIPTION
Plain punctuation everywhere in README, docs, site pages, NOTICE and script comments/messages. third_party/ and the winemac patch are untouched.

https://claude.ai/code/session_01TiFcqQceFHoQLeJXf63twY