### PR TITLE
Link wineserver against libinotify so Epic installs work (DP-05/DP-06)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -79,6 +79,9 @@ scripts/play.sh epic             # 로그인 → 게임 설치·플레이
 scripts/play.sh epic-kill        # Epic 보틀 종료 (창을 닫아도 런처는 살아 있음, macOS 메뉴바의 Epic 아이콘을 **우클릭**해 열기/Exit, Windows 트레이와 동일, 좌클릭 한 번엔 반응 없음)
 ```
 
+검증 2026-08-30: 런처에서 Hogwarts Legacy 71GB 설치 후 인게임까지(UE4, D3DMetal 경유 D3D12). 알아두실 점 두 가지: 플레이 전에 macOS 입력기를 영어(ABC)로 바꾸세요, 한글 IME가 켜져 있으면 Wine 게임에 키 입력이 전달되지 않습니다. 게임이 전체화면으로 뜨면 게임 자체 디스플레이 설정에서 창 모드로 바꾸면 됩니다(Soju가 강제하지 않습니다).
+
+
 게임은 아직 폭넓게 테스트하지 않았습니다. 커널 안티치트(EAC/BattlEye)가 필요한 게임은 Wine에서 돌지 않습니다.
 
 ## Steam 지원 (Steam판 D2R 포함)

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ scripts/play.sh epic             # log in -> install & play
 scripts/play.sh epic-kill        # stop the Epic bottle (closing the window keeps the launcher running; right-click the Epic icon in the macOS menu bar to reopen or Exit, same as the Windows tray; a plain left click does nothing, as Epic only reacts to the menu)
 ```
 
+Verified 2026-08-30: 71 GB install of Hogwarts Legacy (UE4, D3D12 through D3DMetal) from the launcher, then in-game. Two things to know: switch the macOS input source to English (ABC) before playing, a Korean/Japanese/Chinese IME swallows key presses in Wine games; and if a game starts full screen, set windowed mode in its own display settings (Soju does not force it).
+
 Games have not been broadly tested yet; anything that needs kernel anti-cheat (EAC/BattlEye) will not run under Wine.
 
 ## Steam (including the Steam version of D2R)

--- a/docs/DIAGNOSIS.md
+++ b/docs/DIAGNOSIS.md
@@ -91,6 +91,18 @@ CrossOver 바이너리 의존 0.
 
 결론: 벽 1(`WRITECOPY`)은 libcef 버전에 따라 걸리는 일반 문제일 수 있지만, 벽 1-b(GPU 프로세스 사망)는 Battle.net의 CEF 빌드/설정 고유. 다른 CEF 런처(GOG Galaxy·EA app·Ubisoft Connect)도 같은 절차로 먼저 "그냥 돌려보는" 것이 맞다.
 
+## Epic 게임 설치 실패 DP-05 / DP-06: wineserver에 inotify가 빠져 있었다 (2026-08-30)
+
+증상: 런처 로그인·스토어까지 되는데 Install을 누르면 아무 변화가 없고, 런처 로그에 `DirectoryPreparation: Returning result: DP-05` 후 60초 뒤 `Reporting Alert code: DP-06`이 찍힌다.
+
+원인: Epic 런처는 설치 폴더 준비를 별도 프로세스(`EpicGamesLauncher.exe -commandlet=prepareinstalldir`)에 맡기고, 둘은 `C:/ProgramData/Epic/EpicGamesLauncher/com/` 폴더에 파일을 쓰고 `ReadDirectoryChangesW`로 서로의 응답을 기다린다. Wine은 디렉터리 변경 알림을 inotify로만 구현하고(`server/change.c`), macOS에서는 CrossOver가 kqueue 기반 `libinotify`를 번들해 wineserver에 링크한다. 우리 빌드는 configure가 `libinotify`를 못 찾아(`config.log: Package libinotify was not found`) 알림 없이 빌드됐고, 양쪽이 서로의 파일을 영영 못 본 채 타임아웃(commandlet 50초 → DP-05, 런처 60초 → DP-06)으로 끝났다. `LogDirectoryWatcher: A directory notification for '.../com' was aborted`가 그 흔적이다.
+
+확인: `otool -L cx26-engine/bin/wineserver`에 libinotify 없음. 진짜 CrossOver의 wineserver는 `@rpath/libinotify.0.dylib`를 링크한다.
+
+해결: `third_party/libinotify-kqueue/sys/inotify.h`(MIT)를 동봉하고 configure에 `INOTIFY_CFLAGS/INOTIFY_LIBS`를 넘겨 wineserver를 libinotify에 링크(`build-engine.sh`), 설치 후 install name을 `@rpath/libinotify.0.dylib`로 교체. 적용 즉시 71GB Hogwarts Legacy 설치가 진행됐고 게임도 실행됐다(AMD 드라이버 경고창은 OK로 넘어감, D3D12는 D3DMetal이 처리). Sikarugir#256의 DP-07은 다른 원인(`GetNamedSecurityInfoW` 합성 SD, CX HACK 27245)이며 이 핵은 우리 엔진에 이미 들어 있다.
+
+부수 확인: 한글 IME가 켜져 있으면 게임이 키 입력을 못 받는다(입력기를 ABC로). 이 alert 코드들은 Whisky/Kegworks 계열 빌드에도 같은 이유로 해당될 가능성이 높다(그쪽 wineserver의 libinotify 링크 여부로 판별 가능).
+
 ## 벽 2: Battle.net Agent caller 서명 검증 실패 (해결됨)
 
 ### 증상

--- a/scripts/build-engine.sh
+++ b/scripts/build-engine.sh
@@ -9,6 +9,7 @@
 set -euo pipefail
 
 WORK="${WORK:-$HOME/.battlenet-macos/build}"
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
 SRC_URL="https://media.codeweavers.com/pub/crossover/source/crossover-sources-26.3.0.tar.gz"
 FT_URL="https://download.savannah.gnu.org/releases/freetype/freetype-2.13.3.tar.gz"
 DEPS="$WORK/deps"
@@ -53,7 +54,13 @@ arch -x86_64 "$WINE/configure" \
   --enable-archs=i386,x86_64 --without-x --disable-tests \
   FREETYPE_CFLAGS="-I$DEPS/include/freetype2" FREETYPE_LIBS="-L$DEPS/lib -lfreetype" \
   GNUTLS_CFLAGS="-I/opt/homebrew/include" GNUTLS_LIBS="-L$DEPS/lib -lgnutls" \
+  INOTIFY_CFLAGS="-I$REPO/third_party/libinotify-kqueue" INOTIFY_LIBS="-L$DEPS/lib -linotify" \
   LDFLAGS="-L$DEPS/lib" CC="clang -arch x86_64" CXX="clang++ -arch x86_64"
+# wineserver must link libinotify (kqueue-backed inotify shim from the dylib stack):
+# Wine implements ReadDirectoryChangesW on top of inotify only. Without it the
+# Epic Games Launcher never sees its install helper's reply (DP-05 / DP-06).
+grep -q '#define HAVE_SYS_INOTIFY_H 1' include/config.h \
+  || { echo "configure did not pick up sys/inotify.h; check third_party/libinotify-kqueue"; exit 1; }
 # Fix the soname to the dylib's real name
 sed -i '' 's|#define SONAME_LIBGNUTLS.*|#define SONAME_LIBGNUTLS "libgnutls.30.dylib"|' include/config.h
 
@@ -85,6 +92,8 @@ PL
 for b in wine wine64 wineserver wine-preloader; do
   f="$ENGINE/bin/$b"; [ -f "$f" ] || continue
   install_name_tool -add_rpath "@loader_path/../lib" "$f" 2>/dev/null || true
+  # the dylib stack's libinotify carries a bare install name; point it at rpath
+  install_name_tool -change libinotify.dylib @rpath/libinotify.0.dylib "$f" 2>/dev/null || true
   codesign -f -s - --entitlements "$WORK/ent.plist" "$f" 2>/dev/null || true
 done
 

--- a/third_party/libinotify-kqueue/LICENSE
+++ b/third_party/libinotify-kqueue/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2011-2014 Dmitry Matveev <me@dmitrymatveev.co.uk>
+Copyright (c) 2014-2021 Vladimir Kondratyev <vladimir@kondratyev.su>
+The software is redistributed under the terms of MIT License.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+

--- a/third_party/libinotify-kqueue/NOTICE
+++ b/third_party/libinotify-kqueue/NOTICE
@@ -1,0 +1,3 @@
+sys/inotify.h is taken from libinotify-kqueue (https://github.com/libinotify-kqueue/libinotify-kqueue), MIT license, see LICENSE.
+
+Only the header is vendored. The matching libinotify.dylib comes with the x86_64 dylib stack fetched by scripts/get-components.sh. Wine's wineserver needs both to build with directory-change notifications (ReadDirectoryChangesW); without them the Epic Games Launcher cannot talk to its install helper and every install fails with DP-05/DP-06.

--- a/third_party/libinotify-kqueue/sys/inotify.h
+++ b/third_party/libinotify-kqueue/sys/inotify.h
@@ -1,0 +1,144 @@
+#ifndef __BSD_INOTIFY_H__
+#define __BSD_INOTIFY_H__
+
+#if defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)
+#include <stdint.h>
+#define LIBINOTIFY_FLEXIBLE_ARRAY_MEMBER /**/
+#else
+#include <inttypes.h>
+#define LIBINOTIFY_FLEXIBLE_ARRAY_MEMBER 0
+#endif
+
+#ifndef __THROW
+  #ifdef __cplusplus
+    #define __THROW throw()
+  #else
+    #define __THROW
+  #endif
+#endif
+
+/*
+ * Libinotify-specific: Default size of communication socket buffer in bytes.
+ * This defines a recommended read(2) buffer size for libinotify event
+ * consumers. Lower values can cause partial event reads. Bigger values
+ * is just a wasting of memory.
+ * The value is arbitrary, has been acquired from code sample in linux
+ * inotify(7) man page and seems to be very common among the inotify clients.
+ */
+#define IN_SOCKBUFSIZE			0
+#define	IN_DEF_SOCKBUFSIZE		4096
+/* linux`s /proc/sys/fs/inotify/max_queued_events counterpart */
+#define IN_MAX_QUEUED_EVENTS		1
+#define IN_DEF_MAX_QUEUED_EVENTS	16384
+/* linux`s /proc/sys/fs/inotify/max_user_instances counterpart */
+#define IN_MAX_USER_INSTANCES		2
+#define IN_DEF_MAX_USER_INSTANCES	2147483646
+
+/* Flags for the parameter of inotify_init1. */
+#define IN_CLOEXEC	02000000	/* Linux x86 O_CLOEXEC */
+#define IN_NONBLOCK	00004000	/* Linux x86 O_NONBLOCK */
+/* libinotify-specific - Direct mode operation. See below. */
+#define	IN_DIRECT	0x80000000
+
+/* Structure describing an inotify event. */
+__extension__ struct inotify_event
+{
+    int wd;          /* Watch descriptor.  */
+    uint32_t mask;   /* Watch mask.  */
+    uint32_t cookie; /* Cookie to synchronize two events.  */
+    uint32_t len;    /* Length (including NULLs) of name.  */
+    char name[LIBINOTIFY_FLEXIBLE_ARRAY_MEMBER];  /* Name.  */
+};
+
+
+/* Supported events suitable for MASK parameter of INOTIFY_ADD_WATCH.  */
+#define IN_ACCESS        0x00000001 /* File was accessed.  */
+#define IN_MODIFY        0x00000002 /* File was modified.  */
+#define IN_ATTRIB        0x00000004 /* Metadata changed.  */
+#define IN_CLOSE_WRITE   0x00000008 /* Writtable file was closed.  */
+#define IN_CLOSE_NOWRITE 0x00000010 /* Unwrittable file closed.  */
+#define IN_CLOSE         (IN_CLOSE_WRITE | IN_CLOSE_NOWRITE) /* Close.  */
+#define IN_OPEN          0x00000020 /* File was opened.  */
+#define IN_MOVED_FROM    0x00000040 /* File was moved from X.  */
+#define IN_MOVED_TO      0x00000080 /* File was moved to Y.  */
+#define IN_MOVE          (IN_MOVED_FROM | IN_MOVED_TO) /* Moves.  */
+#define IN_CREATE        0x00000100 /* Subfile was created.  */
+#define IN_DELETE        0x00000200 /* Subfile was deleted.  */
+#define IN_DELETE_SELF   0x00000400 /* Self was deleted.  */
+#define IN_MOVE_SELF     0x00000800 /* Self was moved.  */
+
+
+/* Additional events and flags. Some of these flags are unsupported,
+   but still should be present */
+#define IN_UNMOUNT	 0x00002000	/* Backing fs was unmounted.  */
+#define IN_Q_OVERFLOW	 0x00004000	/* Event queued overflowed.  */
+#define IN_IGNORED	 0x00008000	/* File was ignored.  */
+
+#define IN_ONLYDIR	 0x01000000	/* Only watch the path if it is a
+					   directory.  */
+#define IN_DONT_FOLLOW	 0x02000000	/* Do not follow a sym link.  */
+#define IN_EXCL_UNLINK	 0x04000000	/* Exclude events on unlinked
+					   objects.  */
+#define IN_MASK_ADD	 0x20000000	/* Add to the mask of an already
+					   existing watch.  */
+#define IN_ISDIR	 0x40000000	/* Event occurred against dir.  */
+#define IN_ONESHOT	 0x80000000	/* Only send event once.  */
+
+
+/*
+ * All of the events - we build the list by hand so that we can add flags in
+ * the future and not break backward compatibility.  Apps will get only the
+ * events that they originally wanted.  Be sure to add new events here!
+ */
+#define IN_ALL_EVENTS	(IN_ACCESS | IN_MODIFY | IN_ATTRIB | IN_CLOSE_WRITE | \
+			 IN_CLOSE_NOWRITE | IN_OPEN | IN_MOVED_FROM | IN_MOVE_SELF | \
+			 IN_MOVED_TO | IN_DELETE | IN_CREATE | IN_DELETE_SELF)
+
+__BEGIN_DECLS
+
+/* Create and initialize inotify-kqueue instance. */
+int inotify_init (void) __THROW;
+
+/* Create and initialize inotify-kqueue instance. */
+int inotify_init1 (int flags) __THROW;
+
+/* Add watch of object NAME to inotify-kqueue instance FD. Notify about
+   events specified by MASK. */
+int inotify_add_watch (int fd, const char *name, uint32_t mask) __THROW;
+
+/* Remove the watch specified by WD from the inotify instance FD. */
+int inotify_rm_watch (int fd, int wd) __THROW;
+
+/* Libinotify specific. Set inotify instance parameter. */
+int libinotify_set_param (int fd, int param, intptr_t value) __THROW;
+#define inotify_set_param(fd, p, v)	libinotify_set_param(fd, p, v)
+
+struct iovec;
+
+/*
+ * Libinotify-specific: Direct mode operation.
+ * In this mode the fd handed over to the user isn't a read()able one, but is
+ * actually a kqueue fd. This allows to reduce some copying overhead at
+ * the cost of adapting the library client code. The mode is activated by passing
+ * IN_DIRECT to inotify_init1().
+ */
+
+/* Wait or poll for events in direct mode. This call boils down to kevent().
+ * Events are returned as an array of iovec structures, where iov_base points to
+ * an inotify_event. Each vector is terminated with an item with iov_base = NULL.
+ * The iovec's should be freed using libinotify_free_iovec.
+ */
+/* FIXME: __THROW ? */
+int libinotify_direct_readv (int fd, struct iovec **events, int size, int no_block);
+
+/* Frees a struct iovec obtained from the libinotify_direct_drain call. */
+void libinotify_free_iovec (struct iovec *events);
+
+/* Closes an inotify fd opened in direct mode.
+ * It correctly shuts down an internal worker thread and should be used instead of
+ * plain close() when operating in direct mode. */
+int libinotify_direct_close (int fd);
+
+__END_DECLS
+
+#endif /* __BSD_INOTIFY_H__ */


### PR DESCRIPTION
The engine's wineserver was built without inotify (configure could not find libinotify), so ReadDirectoryChangesW never fired. The Epic Games Launcher relies on it to talk to its prepareinstalldir helper through a shared folder, so every install died with DP-05 then DP-06 while login and the store worked fine.

- vendor sys/inotify.h from libinotify-kqueue (MIT) under third_party/
- pass INOTIFY_CFLAGS/INOTIFY_LIBS to configure and fail the build if sys/inotify.h is not picked up
- rewrite the bare libinotify install name to @rpath after install
- README (en/ko): Hogwarts Legacy 71 GB install and in-game verified, IME and windowed-mode notes
- docs/DIAGNOSIS.md: full write-up

Engine tarball needs a rebuild (engine-v1.2) for existing installs; scripts alone do not fix a downloaded engine.