### PR TITLE
Installer: choose any combination of launchers, one app per launcher

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -34,10 +34,10 @@ Homebrew로도 됩니다:
 
 ```bash
 brew install BCD1210/soju/soju
-soju install     # 이후: soju battlenet / soju d2r / soju steam
+soju install     # 이후: soju battlenet / soju d2r / soju steam / soju epic / soju gog
 ```
 
-프리빌드 엔진(~350MB)을 받고, 애플 무료 GPTK 다운로드(애플이 재배포 금지한 파일 1개)를 안내하고, 블리자드 공식 설치기로 Battle.net을 자동 설치한 뒤 `~/Applications/Battle.net.app`을 만들어줍니다. 로그인하고 플레이하세요.
+설치기는 프리빌드 엔진(~350MB)을 받고, 애플 무료 GPTK 다운로드(애플이 재배포 금지한 파일 1개)를 안내한 뒤, 원하는 런처를 묻습니다. Battle.net, Steam, Epic Games Launcher, GOG GALAXY 중 아무 조합이나 고르면 각각 공식 설치기로 별도 보틀에 설치하고, 런처마다 더블클릭용 앱을 `~/Applications`에 만들어 줍니다(`Battle.net.app`, `Steam (Windows).app`, `Epic Games Launcher.app`, `GOG GALAXY.app`). 비대화형: `SOJU_PLATFORMS=battlenet,epic,gog curl ... | bash`. 로그인하고 플레이하세요.
 
 ## 직접 빌드하고 싶다면: CrossOver 불필요
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -27,7 +27,7 @@ CodeWeavers가 GPL로 공개한 소스(Wine 11.0, CrossOver 26.3 소스 드롭)�
 ## 설치 (한 줄)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/BCD1210/soju/main/install.sh | bash
+curl -fsSL bcd1210.github.io/soju/install.sh | bash
 ```
 
 Homebrew로도 됩니다:

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ Or via Homebrew:
 
 ```bash
 brew install BCD1210/soju/soju
-soju install     # then: soju battlenet / soju d2r / soju epic / soju steam
+soju install     # then: soju battlenet / soju d2r / soju steam / soju epic / soju gog
 ```
 
-Downloads the prebuilt engine (~350 MB), walks you through Apple's free GPTK download (the one file Apple forbids redistributing), auto-installs Battle.net with Blizzard's official installer, and drops a `Battle.net.app` in `~/Applications`. Log in and play.
+The installer downloads the prebuilt engine (~350 MB), walks you through Apple's free GPTK download (the one file Apple forbids redistributing), then asks which launchers you want, any combination of Battle.net, Steam, Epic Games Launcher and GOG GALAXY, installs each with its official installer into its own bottle, and drops a double-clickable app per launcher in `~/Applications` (`Battle.net.app`, `Steam (Windows).app`, `Epic Games Launcher.app`, `GOG GALAXY.app`). Non-interactive: `SOJU_PLATFORMS=battlenet,epic,gog curl ... | bash`. Log in and play.
 
 ## Build it yourself instead: no CrossOver required
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Plus one trap: never put Apple platform binaries (`nohup`, `arch`, …) in the l
 ## Install (one line)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/BCD1210/soju/main/install.sh | bash
+curl -fsSL bcd1210.github.io/soju/install.sh | bash
 ```
 
 Or via Homebrew:

--- a/docs/index.html
+++ b/docs/index.html
@@ -29,7 +29,7 @@ on M-series Macs. No CrossOver license needed.</p>
 soju install     # Battle.net + Diablo II: Resurrected
 soju steam-install</code></pre>
 <p>Or without Homebrew:</p>
-<pre><code>curl -fsSL https://raw.githubusercontent.com/BCD1210/soju/main/install.sh | bash</code></pre>
+<pre><code>curl -fsSL bcd1210.github.io/soju/install.sh | bash</code></pre>
 <p><a class="btn" href="https://github.com/BCD1210/soju">View on GitHub</a></p>
 
 <h2>Guides</h2>

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Short-URL entry point for the Soju installer (served by GitHub Pages).
+#   curl -fsSL bcd1210.github.io/soju/install.sh | bash
+# Downloads and runs the real installer from the main branch.
+set -euo pipefail
+curl -fsSL "https://raw.githubusercontent.com/BCD1210/soju/main/install.sh" | bash

--- a/install.sh
+++ b/install.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
-# Soju one-line installer: Battle.net + Diablo II: Resurrected on Apple Silicon, no CrossOver.
+# Soju one-line installer: Battle.net, Steam, Epic and GOG launchers on Apple Silicon, no CrossOver.
 #   curl -fsSL https://raw.githubusercontent.com/BCD1210/soju/main/install.sh | bash
+#   SOJU_PLATFORMS=battlenet,epic,gog curl ... | bash     (non-interactive selection)
 #
 # What it does:
 #   1. Downloads the prebuilt GPL Wine engine (built from CodeWeavers' published sources)
 #   2. Asks you to download Apple's Game Porting Toolkit once (Apple forbids redistribution)
-#   3. Creates a bottle and runs Blizzard's official Battle.net installer (automatic)
-#   4. Creates ~/Applications/Battle.net.app
+#   3. Asks which launchers you want (any combination) and installs each one with
+#      its official installer into its own bottle
+#   4. Creates a double-clickable app in ~/Applications for each launcher
 set -euo pipefail
 
 REPO="BCD1210/soju"
@@ -83,68 +85,117 @@ EOT
   fi
 fi
 
-# ---------- 3. Bottle + Battle.net ----------
-export WINEPREFIX="$BOTTLE" WINEDEBUG=fixme-all WINEMSYNC=1 ROSETTA_ADVERTISE_AVX=1 WINE_SIMULATE_WRITECOPY=1
-export CX_APPLEGPTK_LIBD3DSHARED_PATH="$ENGINE/lib/external/libd3dshared.dylib"
-export DYLD_FALLBACK_LIBRARY_PATH="$ENGINE/lib:/usr/lib"
-if [ -f "$BOTTLE/drive_c/Program Files (x86)/Battle.net/Battle.net.exe" ]; then
-  say "[3/4] Battle.net already installed - skipping"
+# ---------- 3. Launchers ----------
+# The bottle scripts live in the repo; fetch a copy next to the engine so the
+# one-line installer can use them (a checkout running install.sh uses itself).
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd || true)"
+if [ -n "$SELF_DIR" ] && [ -f "$SELF_DIR/scripts/play.sh" ]; then
+  SOJU_DIR="$SELF_DIR"
 else
-  say "[3/4] Creating the bottle + installing Battle.net automatically (5-10 min)"
-  "$ENGINE/bin/wine" wineboot -u >/dev/null 2>&1 || true
-  "$ENGINE/bin/wineserver" -w
-  W="$ENGINE/bin/wine"
-  "$W" reg add 'HKCU\Software\Wine\WineDbg' /v ShowCrashDialog /t REG_DWORD /d 0 /f >/dev/null 2>&1
-  for HIVE in 'HKLM\Software\Microsoft\Windows NT\CurrentVersion\AeDebug' \
-              'HKLM\Software\Wow6432Node\Microsoft\Windows NT\CurrentVersion\AeDebug'; do
-    "$W" reg add "$HIVE" /v Debugger /t REG_SZ /d 'C:\windows\system32\rundll32.exe kernel32.dll,Sleep' /f >/dev/null 2>&1
-    "$W" reg add "$HIVE" /v Auto /t REG_SZ /d 1 /f >/dev/null 2>&1
-  done
-  "$ENGINE/bin/wineserver" -w
-  SETUP="$BASE/Battle.net-Setup.exe"
-  [ -f "$SETUP" ] || curl -fL "https://downloader.battle.net/download/getInstaller?os=win&installer=Battle.net-Setup.exe" -o "$SETUP"
-  "$ENGINE/bin/wine" "$SETUP" --lang=enUS >/dev/null 2>&1 || true
-  for i in $(seq 1 60); do
-    [ -f "$BOTTLE/drive_c/Program Files (x86)/Battle.net/Battle.net.exe" ] && break; sleep 10
-  done
-  [ -f "$BOTTLE/drive_c/Program Files (x86)/Battle.net/Battle.net.exe" ] \
-    || { echo "Install failed - check the logs in $BOTTLE/drive_c/ProgramData/Battle.net/Setup"; exit 1; }
-  "$ENGINE/bin/wineserver" -k 2>/dev/null || true
-  echo "Battle.net installed"
+  SOJU_DIR="$BASE/soju"
+  say "Fetching the Soju scripts into $SOJU_DIR"
+  rm -rf "$SOJU_DIR.tmp"; mkdir -p "$SOJU_DIR.tmp"
+  curl -fsSL "https://github.com/$REPO/archive/refs/heads/main.tar.gz" | tar -xz -C "$SOJU_DIR.tmp" --strip-components=1
+  rm -rf "$SOJU_DIR"; mv "$SOJU_DIR.tmp" "$SOJU_DIR"
 fi
+chmod +x "$SOJU_DIR"/scripts/*.sh "$SOJU_DIR"/scripts/soju 2>/dev/null || true
 
-# ---------- 4. App bundle ----------
-say "[4/4] Creating Battle.net.app"
-REAPER="$BASE/soju-reaper.sh"
-[ -f "$REAPER" ] || curl -fsSL "https://raw.githubusercontent.com/$REPO/main/scripts/soju-reaper.sh" -o "$REAPER" 2>/dev/null || true
-chmod +x "$REAPER" 2>/dev/null || true
-APP="$HOME/Applications/Battle.net.app"
-mkdir -p "$APP/Contents/MacOS"
-cat > "$APP/Contents/MacOS/launcher" <<EOF
+ALL="battlenet steam epic gog"
+if [ -n "${SOJU_PLATFORMS:-}" ]; then
+  PLATFORMS="$(echo "$SOJU_PLATFORMS" | tr ',' ' ')"
+else
+  say "[3/4] Which launchers do you want? (numbers separated by spaces, Enter = Battle.net only)"
+  cat <<'EOT'
+  1) Battle.net           (Diablo II: Resurrected etc.)
+  2) Steam                (Windows client on Homebrew wine-stable, D3D11 games via DXMT)
+  3) Epic Games Launcher
+  4) GOG GALAXY
+EOT
+  read -r -p "  Your choice [1]: " choice < "$TTY" || choice=1
+  [ -n "$choice" ] || choice=1
+  PLATFORMS=""
+  for c in $choice; do
+    case "$c" in
+      1|battlenet) PLATFORMS="$PLATFORMS battlenet" ;;
+      2|steam)     PLATFORMS="$PLATFORMS steam" ;;
+      3|epic)      PLATFORMS="$PLATFORMS epic" ;;
+      4|gog)       PLATFORMS="$PLATFORMS gog" ;;
+      *) echo "  Ignoring unknown choice: $c" ;;
+    esac
+  done
+fi
+for p in $PLATFORMS; do case " $ALL " in *" $p "*) ;; *) echo "Unknown platform: $p"; exit 1;; esac; done
+[ -n "$PLATFORMS" ] || { echo "Nothing selected."; exit 1; }
+echo "  Installing:$PLATFORMS"
+
+export ENGINE
+for p in $PLATFORMS; do
+  case "$p" in
+    battlenet)
+      if [ -f "$BOTTLE/drive_c/Program Files (x86)/Battle.net/Battle.net.exe" ]; then
+        say "Battle.net already installed - skipping"
+      else
+        say "Battle.net: creating the bottle + running Blizzard's installer (5-10 min)"
+        WINEPREFIX="$BOTTLE" bash "$SOJU_DIR/scripts/create-bottle.sh"
+      fi ;;
+    steam)
+      if [ -f "$BASE/steam-bottle/drive_c/Program Files (x86)/Steam/steam.exe" ]; then
+        say "Steam already installed - skipping"
+      else
+        say "Steam: Homebrew wine-stable + Steam installer"
+        bash "$SOJU_DIR/scripts/create-steam-bottle.sh"
+      fi ;;
+    epic)
+      if [ -f "$BASE/epic-bottle/drive_c/Program Files/Epic Games/Launcher/Portal/Binaries/Win64/EpicGamesLauncher.exe" ]; then
+        say "Epic Games Launcher already installed - skipping"
+      else
+        say "Epic Games Launcher: creating the bottle + running Epic's installer"
+        bash "$SOJU_DIR/scripts/create-epic-bottle.sh"
+      fi ;;
+    gog)
+      if [ -f "$BASE/gog-bottle/drive_c/Program Files/GOG Galaxy/GalaxyClient.exe" ]; then
+        say "GOG GALAXY already installed - skipping"
+      else
+        say "GOG GALAXY: creating the bottle + running GOG's installer"
+        bash "$SOJU_DIR/scripts/create-gog-bottle.sh"
+      fi ;;
+  esac
+done
+
+# ---------- 4. App bundles ----------
+say "[4/4] Creating apps in ~/Applications"
+make_app(){   # name, play.sh mode, bundle id
+  local APP="$HOME/Applications/$1.app"
+  mkdir -p "$APP/Contents/MacOS"
+  cat > "$APP/Contents/MacOS/launcher" <<EOF
 #!/bin/bash
-export WINEPREFIX="$BOTTLE" WINEDEBUG=fixme-all WINEMSYNC=1 ROSETTA_ADVERTISE_AVX=1 WINE_SIMULATE_WRITECOPY=1
-export CX_APPLEGPTK_LIBD3DSHARED_PATH="$ENGINE/lib/external/libd3dshared.dylib"
-export DYLD_FALLBACK_LIBRARY_PATH="$ENGINE/lib:/usr/lib"
-BN="\$WINEPREFIX/drive_c/Program Files (x86)/Battle.net"
-for v in "\$BN"/Battle.net.[0-9]*; do [ -d "\$v" ] && cp -f "\$BN/Battle.net.exe" "\$v/Battle.net.exe" 2>/dev/null; done
-# Reap zombie game processes so quitting the game really quits it
-pgrep -f "soju-reaper.sh \$WINEPREFIX" >/dev/null 2>&1 || { [ -x "$REAPER" ] && ( "$REAPER" "\$WINEPREFIX" "$ENGINE/bin/wineserver" >/dev/null 2>&1 & ); }
-# Battle.net.exe directly (not Launcher.exe): CrossOver's private compat DB injects these two
-# switches; without them CEF's GPU process dies and the main window stays transparent.
-exec "$ENGINE/bin/wine" "C:\\\\Program Files (x86)\\\\Battle.net\\\\Battle.net.exe" --disable-gpu-compositing --from-launcher --in-process-gpu --use-gl=swiftshader
+export ENGINE="$ENGINE"
+exec "$SOJU_DIR/scripts/play.sh" $2
 EOF
-chmod +x "$APP/Contents/MacOS/launcher"
-cat > "$APP/Contents/Info.plist" <<'EOF'
+  chmod +x "$APP/Contents/MacOS/launcher"
+  cat > "$APP/Contents/Info.plist" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0"><dict>
-<key>CFBundleName</key><string>Battle.net</string>
+<key>CFBundleName</key><string>$1</string>
 <key>CFBundleExecutable</key><string>launcher</string>
-<key>CFBundleIdentifier</key><string>app.soju.battlenet</string>
+<key>CFBundleIdentifier</key><string>$3</string>
 <key>CFBundlePackageType</key><string>APPL</string>
 </dict></plist>
 EOF
-codesign -f -s - "$APP" 2>/dev/null || true
+  codesign -f -s - "$APP" 2>/dev/null || true
+  echo "  ~/Applications/$1.app"
+}
+mkdir -p "$HOME/Applications"
+for p in $PLATFORMS; do
+  case "$p" in
+    battlenet) make_app "Battle.net" battlenet app.soju.battlenet ;;
+    steam)     make_app "Steam (Windows)" steam app.soju.steam ;;
+    epic)      make_app "Epic Games Launcher" epic app.soju.epic ;;
+    gog)       make_app "GOG GALAXY" gog app.soju.gog ;;
+  esac
+done
 
-say "Done! 🍶  Double-click ~/Applications/Battle.net.app, log in, install and play"
+say "Done! 🍶  Double-click the app(s) above, log in, install and play."
+echo "Command line: $SOJU_DIR/scripts/soju  (battlenet | d2r | steam | epic | gog, plus *-kill)"
 GPTK_OK || echo "NOTE: GPTK was skipped - run scripts/get-gptk.sh before launching a game."


### PR DESCRIPTION
install.sh now asks which launchers to set up (Battle.net, Steam, Epic Games Launcher, GOG GALAXY, any combination; SOJU_PLATFORMS=... for non-interactive runs), installs each with the repo's bottle scripts, and creates a double-clickable app per launcher in ~/Applications. All apps go through play.sh, so tray restore on Dock click and the input-source switch apply to them too.

The one-line installer fetches a copy of the repo scripts into ~/.battlenet-macos/soju; a checkout running install.sh uses itself. Battle.net's inline install block is replaced by scripts/create-bottle.sh (same steps).

Tested with all four already installed: skips each, creates the four apps, GOG GALAXY.app launches through play.sh.