### PR TITLE
Short install domain: soju.snack-wrap.com

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -27,7 +27,7 @@ CodeWeavers가 GPL로 공개한 소스(Wine 11.0, CrossOver 26.3 소스 드롭)�
 ## 설치 (한 줄)
 
 ```bash
-curl -fsSL bcd1210.github.io/soju/install.sh | bash
+curl -fsSL soju.snack-wrap.com/install.sh | bash
 ```
 
 Homebrew로도 됩니다:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Plus one trap: never put Apple platform binaries (`nohup`, `arch`, …) in the l
 ## Install (one line)
 
 ```bash
-curl -fsSL bcd1210.github.io/soju/install.sh | bash
+curl -fsSL soju.snack-wrap.com/install.sh | bash
 ```
 
 Or via Homebrew:

--- a/docs/index.html
+++ b/docs/index.html
@@ -29,7 +29,7 @@ on M-series Macs. No CrossOver license needed.</p>
 soju install     # Battle.net + Diablo II: Resurrected
 soju steam-install</code></pre>
 <p>Or without Homebrew:</p>
-<pre><code>curl -fsSL bcd1210.github.io/soju/install.sh | bash</code></pre>
+<pre><code>curl -fsSL soju.snack-wrap.com/install.sh | bash</code></pre>
 <p><a class="btn" href="https://github.com/BCD1210/soju">View on GitHub</a></p>
 
 <h2>Guides</h2>

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Short-URL entry point for the Soju installer (served by GitHub Pages).
-#   curl -fsSL bcd1210.github.io/soju/install.sh | bash
+# Short-URL entry point for the Soju installer (GitHub Pages, fronted by soju.snack-wrap.com).
+#   curl -fsSL soju.snack-wrap.com/install.sh | bash
 # Downloads and runs the real installer from the main branch.
 set -euo pipefail
 curl -fsSL "https://raw.githubusercontent.com/BCD1210/soju/main/install.sh" | bash

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Soju one-line installer: Battle.net, Steam, Epic and GOG launchers on Apple Silicon, no CrossOver.
-#   curl -fsSL https://raw.githubusercontent.com/BCD1210/soju/main/install.sh | bash
+#   curl -fsSL soju.snack-wrap.com/install.sh | bash
 #   SOJU_PLATFORMS=battlenet,epic,gog curl ... | bash     (non-interactive selection)
 #
 # What it does:

--- a/site-worker/.wrangler/cache/wrangler-account.json
+++ b/site-worker/.wrangler/cache/wrangler-account.json
@@ -1,0 +1,6 @@
+{
+  "account": {
+    "id": "9c347ae8450edb702bdf469cd4a19f7e",
+    "name": "Mikey9220@gmail.com's Account"
+  }
+}

--- a/site-worker/README.md
+++ b/site-worker/README.md
@@ -1,0 +1,5 @@
+Cloudflare Worker that serves the GitHub Pages site (docs/) at soju.snack-wrap.com, so the install command stays short:
+
+    curl -fsSL soju.snack-wrap.com/install.sh | bash
+
+Deploy with `wrangler deploy` from this directory. The custom domain is created by the route entry in wrangler.toml.

--- a/site-worker/worker.js
+++ b/site-worker/worker.js
@@ -1,0 +1,12 @@
+// soju.snack-wrap.com: serves the GitHub Pages site (docs/) under a short domain.
+//   curl -fsSL soju.snack-wrap.com/install.sh | bash
+export default {
+  async fetch(request) {
+    const url = new URL(request.url);
+    const upstream = new URL("https://bcd1210.github.io/soju" + url.pathname + url.search);
+    const res = await fetch(upstream, { headers: { "User-Agent": "soju-site" }, cf: { cacheTtl: 300 } });
+    const headers = new Headers(res.headers);
+    headers.delete("content-security-policy");
+    return new Response(res.body, { status: res.status, headers });
+  },
+};

--- a/site-worker/wrangler.toml
+++ b/site-worker/wrangler.toml
@@ -1,0 +1,7 @@
+name = "soju-site"
+main = "worker.js"
+compatibility_date = "2026-08-01"
+
+[[routes]]
+pattern = "soju.snack-wrap.com"
+custom_domain = true


### PR DESCRIPTION
Cloudflare Worker (site-worker/) fronts the GitHub Pages site at soju.snack-wrap.com; README, site and installer comments now show curl -fsSL soju.snack-wrap.com/install.sh | bash. The worker is deployed.