### PR TITLE
doctor, update and uninstall commands; Simplified Chinese README

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -10,7 +10,7 @@ CodeWeavers가 GPL로 공개한 소스(Wine 11.0, CrossOver 26.3 소스 드롭)�
 
 > 상태(2026-08): **전 구간 동작**: 배틀넷 로그인·Agent·D2R 인게임 렌더링(D3DMetal), Epic Games Launcher 로그인·게임 설치(메뉴바 트레이), GOG GALAXY 로그인, Steam 로그인 + D3D11 게임. M4 Pro / macOS 26.5에서 검증.
 
-*[English README](README.md)*
+*[English README](README.md) · [简体中文说明](README.zh.md)*
 
 ## 핵심 발견 3가지
 
@@ -38,6 +38,14 @@ soju install     # 이후: soju battlenet / soju d2r / soju steam / soju epic / 
 ```
 
 설치기는 프리빌드 엔진(~350MB)을 받고, 애플 무료 GPTK 다운로드(애플이 재배포 금지한 파일 1개)를 안내한 뒤, 원하는 런처를 묻습니다. Battle.net, Steam, Epic Games Launcher, GOG GALAXY 중 아무 조합이나 고르면 각각 공식 설치기로 별도 보틀에 설치하고, 런처마다 더블클릭용 앱을 `~/Applications`에 만들어 줍니다(`Battle.net.app`, `Steam (Windows).app`, `Epic Games Launcher.app`, `GOG GALAXY.app`). 비대화형: `SOJU_PLATFORMS=battlenet,epic,gog curl ... | bash`. 로그인하고 플레이하세요.
+
+## 일상 명령
+
+```bash
+soju doctor      # 스택 전체 점검, 뭐가 문제인지 출력 (이슈 올릴 때 이 출력을 붙여주세요)
+soju update      # 스크립트와 엔진 업데이트 (GPTK와 보틀은 그대로 둠)
+soju uninstall   # 앱·보틀·엔진 제거, 항목마다 확인 후 진행
+```
 
 ## 직접 빌드하고 싶다면: CrossOver 불필요
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Built from CodeWeavers' published GPL sources (Wine 11.0, CrossOver 26.3 source 
 
 > Status (2026-08): **Working end-to-end**: Battle.net login, Agent, and D2R in-game rendering (D3DMetal); Epic Games Launcher login and game installs (tray icon in the menu bar); GOG GALAXY login; Steam client login + D3D11 games. Verified on an M4 Pro running macOS 26.5.
 
-*[한국어 README](README.ko.md)*
+*[한국어 README](README.ko.md) · [简体中文说明](README.zh.md)*
 
 ## Why this exists
 
@@ -42,6 +42,14 @@ soju install     # then: soju battlenet / soju d2r / soju steam / soju epic / so
 ```
 
 The installer downloads the prebuilt engine (~350 MB), walks you through Apple's free GPTK download (the one file Apple forbids redistributing), then asks which launchers you want, any combination of Battle.net, Steam, Epic Games Launcher and GOG GALAXY, installs each with its official installer into its own bottle, and drops a double-clickable app per launcher in `~/Applications` (`Battle.net.app`, `Steam (Windows).app`, `Epic Games Launcher.app`, `GOG GALAXY.app`). Non-interactive: `SOJU_PLATFORMS=battlenet,epic,gog curl ... | bash`. Log in and play.
+
+## Everyday commands
+
+```bash
+soju doctor      # checks the whole stack and prints what is wrong (paste this into bug reports)
+soju update      # updates the scripts and the prebuilt engine, keeping GPTK and every bottle
+soju uninstall   # removes apps, bottles and the engine, asking before each one
+```
 
 ## Build it yourself instead: no CrossOver required
 
@@ -116,6 +124,8 @@ Verified on M4 Pro / macOS 26.5: login, library, and an actual D3D11 (Unity) gam
 `libd3dshared.dylib` (inside GPTK) is not just graphics: D2R's loader requires its *non-native code region registration* to get through Rosetta 2. Without it the game freezes at launch even with AVX advertised. Graphics itself can run on pure open-source vkd3d/MoltenVK if D3DMetal is absent.
 
 ### Troubleshooting
+
+Start with `soju doctor`: it checks most of the items below and tells you which one is broken.
 
 - **"Wine Mono Installer" popup** -> step 2 was skipped; run `get-components.sh` then re-run `build-engine.sh`.
 - **Game hangs forever at ~86 MB RAM, 0% CPU** -> `ROSETTA_ADVERTISE_AVX=1` or `libd3dshared` not reaching the game. Launch via `play.sh` only, and check step 4.

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,0 +1,155 @@
+# Soju（简体中文）
+
+> *Wine → Whisky → Kegworks…… 这一轮来自韩国：**Soju** 🍶*
+
+**登录器真的能登录。** 在 Apple Silicon Mac 上运行战网（Battle.net）、Steam、Epic Games Launcher 和 GOG GALAXY。没有黑色登录窗口，没有永远转圈的 "Signing in…"，也不需要 CrossOver 许可证。完全免费的开源 Wine 栈。
+
+如果你是从 Whisky/Kegworks 相关帖子（"战网登录时崩溃"、"Steam 打不开"、"登录器窗口一片空白"）找到这里的：这些正是本仓库记录并解决的问题（CEF 渲染进程在 `PAGE_WRITECOPY` 上触发 `int3`、CEF GPU 进程初始化即死、Steam 的 webhelper）。详见 [docs/DIAGNOSIS.md](docs/DIAGNOSIS.md)。
+
+引擎由 CodeWeavers 公开的 GPL 源码（Wine 11.0，CrossOver 26.3 源码包）用本仓库的脚本编译组装而成。不需要任何付费软件。
+
+> 状态（2026-08）：**全链路可用**：战网登录、Agent、D2R 进入游戏并正常渲染（D3DMetal）；Epic Games Launcher 登录和游戏安装（菜单栏托盘图标）；GOG GALAXY 登录；Steam 客户端登录 + D3D11 游戏。在 M4 Pro / macOS 26.5 上验证。
+
+*[English README](README.md) · [한국어 README](README.ko.md)*
+
+## 为什么会有这个项目
+
+社区 Wine 构建（Whisky、Kegworks 时代的引擎）已经无法运行新版战网和 D2R。商业方案可以用，但其底层 Wine 引擎是 GPL 的，所以我们自己把它编译出来，并记录了撞上的每一堵墙。其中三堵墙此前没有公开解法：
+
+### 三把钥匙
+
+1. **`ROSETTA_ADVERTISE_AVX=1`**：D2R 的加载器要求 AVX 指令集。没有这个环境变量，游戏会在任何图形初始化之前，卡在约 86 MB 内存、0% CPU 的状态永远不动。这就是非 CrossOver 的 Wine 构建上 "D2R 启动即卡死" 的真相。
+
+2. **D3DMetal 符号链接布局**：Apple Game Porting Toolkit 的库必须放在 `lib/external/` 下，而 `lib/wine/x86_64-unix/{d3d10,d3d11,d3d12,dxgi}.so` 必须是指向它的**符号链接**。直接复制文件会破坏 `@loader_path` 解析，D3DMetal 会陷入断言循环。
+
+3. **战网 Agent 调用方签名修复**：Agent 校验连接客户端的签名时，用的是相对文件名，相对于它自己的工作目录（一个带版本号的子目录）解析。把签名过的 `Battle.net.exe` 复制一份到每个 `Battle.net.NNNNN` 子目录即可通过校验（修复错误 `BLZBNTBNA00000005`）。
+
+另外一个陷阱：启动链里绝不能出现 Apple 平台二进制（`nohup`、`arch` 等）。macOS 在 exec 它们时会剥掉 `DYLD_*` 环境变量。
+
+**指南（英文）：** [D2R on Apple Silicon](https://bcd1210.github.io/soju/guides/diablo-2-resurrected-apple-silicon.html) · [Windows Steam client](https://bcd1210.github.io/soju/guides/steam-windows-client-apple-silicon.html) · [Whisky alternatives](https://bcd1210.github.io/soju/guides/whisky-alternative.html)
+
+## 安装（一行命令）
+
+```bash
+curl -fsSL soju.snack-wrap.com/install.sh | bash
+```
+
+或者用 Homebrew：
+
+```bash
+brew install BCD1210/soju/soju
+soju install     # 然后：soju battlenet / soju d2r / soju steam / soju epic / soju gog
+```
+
+安装器会下载预编译引擎（约 350 MB），引导你下载 Apple 免费的 GPTK（唯一一个 Apple 禁止再分发的文件），然后询问你要装哪些登录器（任意组合：战网、Steam、Epic Games Launcher、GOG GALAXY），用各自的官方安装包装进各自独立的 bottle，并在 `~/Applications` 里为每个登录器生成可双击的 app（`Battle.net.app`、`Steam (Windows).app`、`Epic Games Launcher.app`、`GOG GALAXY.app`）。非交互模式：`SOJU_PLATFORMS=battlenet,epic,gog curl ... | bash`。登录，开玩。
+
+## 日常维护
+
+```bash
+soju doctor      # 体检：检查整个栈，指出哪里不对（提 issue 时请附上输出）
+soju update      # 更新脚本和预编译引擎（保留 GPTK 和所有 bottle）
+soju uninstall   # 卸载：逐项确认后删除 app、bottle 和引擎
+```
+
+## 或者完全自己构建：不需要 CrossOver
+
+除了本仓库脚本之外，你唯一要自己下载的是 Apple 免费的 Game Porting Toolkit（一个文件，一个免费 Apple ID 即可）。Apple 禁止再分发它。
+
+```bash
+# 1. 获取脚本
+git clone https://github.com/BCD1210/soju.git && cd soju
+
+# 2. 获取运行时组件（x86_64 动态库 + wine-mono，全部来自免费的 GPL 发布）
+scripts/get-components.sh
+
+# 3. 从 GPL 源码构建引擎（30-60 分钟）
+scripts/build-engine.sh
+
+# 4. 安装 Apple GPTK（从 https://developer.apple.com/games/game-porting-toolkit/
+#    下载 GPTK 的 dmg 并挂载，然后：）
+scripts/get-gptk.sh
+#    （如果你恰好装了 CrossOver，脚本会自动从中提取）
+
+# 5. 创建 bottle + 安装战网（Blizzard 官方安装包，全自动）
+scripts/create-bottle.sh
+
+# 6. 开玩
+scripts/play.sh battlenet   # 登录器 -> 登录 -> 安装并运行你的游戏
+scripts/play.sh d2r         # 直接启动 D2R（离线）
+scripts/play.sh kill        # 全部停止
+```
+
+已经有装好游戏的 CrossOver bottle？`scripts/setup-bottle.sh` 会克隆它（省下 28 GB 的游戏重新下载）。
+
+## Epic Games Launcher
+
+同一个引擎，独立 bottle，不需要额外招数：Epic 的 CEF 在这个构建上 GPU 进程能存活，登录器用原始命令行即可运行。2026-08-29 验证：官方 MSI 无人值守安装（约 30 秒）、登录器界面、登录。
+
+```bash
+scripts/create-epic-bottle.sh    # 官方 Epic MSI，无人值守
+scripts/play.sh epic             # 登录 -> 安装并游玩
+scripts/play.sh epic-kill        # 停止 Epic bottle（关窗口会缩到菜单栏托盘；点 Dock 图标恢复）
+```
+
+2026-08-30 验证：从登录器安装 71 GB 的《霍格沃茨之遗》（UE4，D3D12 走 D3DMetal），进入游戏。两点提示：进游戏前把 macOS 输入法切到英文（ABC），中日韩输入法会吞掉 Wine 游戏里的按键；如果游戏以全屏启动，请在游戏自己的显示设置里改成窗口模式（Soju 不强制）。wine 11.0 的一个已知问题：在多个 Wine 窗口（登录器、游戏、另一个 bottle）之间切换几次后，游戏可能收不到键盘输入，重启游戏即可；上游在 wine 11.11 修复。
+
+### GOG GALAXY
+
+```bash
+scripts/create-gog-bottle.sh      # 独立 bottle，官方网页安装器（静默）
+scripts/play.sh gog               # 登录、安装、游玩
+scripts/play.sh gog-kill          # 停止 GOG bottle（关窗口会缩到菜单栏托盘）
+```
+
+2026-08-30 验证：安装、登录、游戏库。GOG GALAXY 2.x 是 Qt6 + QtWebEngine 而不是 CEF，在这个引擎上窗口会黑屏：Qt 的 D3D11 合成会向 D3DMetal 的 DXGI 要 `IDXGIResource`，而后者没有实现。解法是让 Chromium 走 CPU 渲染（`--disable-gpu`），但 GOG 会自己覆盖 `QTWEBENGINE_CHROMIUM_FLAGS`、无视自己的命令行参数，还会校验自身可执行文件，引擎外部没有任何注入手段。因此引擎带了一个小钩子（`patches/chromium-flags-append.patch`）：每当程序设置 `QTWEBENGINE_CHROMIUM_FLAGS` 时，把 `SOJU_CHROMIUM_FLAGS` 的内容追加上去。`play.sh gog` 会设置它。同一组补丁还加了 `WINE_CUSTOM_FRAME`，阻止 Mac 驱动在 GOG 自绘标题栏上再叠一个 macOS 标题栏。细节见 [docs/DIAGNOSIS.md](docs/DIAGNOSIS.md)。
+
+游戏尚未大范围测试；需要内核级反作弊（EAC/BattlEye）的游戏在 Wine 下无法运行。
+
+## Steam（包括 Steam 版 D2R）
+
+D2R 于 2026 年 2 月以 *Infernal Edition* 上架 Steam。Steam 支持用的是**另一个免费引擎**：新版 Steam 客户端的 CEF 界面在 CrossOver 源码构建上无法渲染（黑窗口，跨进程交换链 + CEF 沙箱问题），但在 Homebrew 的 `wine-stable` 11 上，配合一个强制 `--disable-gpu --single-process` 的小 `steamwebhelper` 包装器就能工作。该修复来自 [notpop/steam-on-m1-wine](https://github.com/notpop/steam-on-m1-wine)（MIT，包装器源码收录在 `third_party/`）。Steam 有自己独立的 bottle，两套栈互不干扰：
+
+```bash
+scripts/create-steam-bottle.sh   # 安装 wine-stable + 包装器 + Valve 官方安装包
+scripts/play.sh steam            # 登录 -> 安装并游玩
+scripts/play.sh steam-kill       # 停止 Steam bottle
+```
+
+在 M4 Pro / macOS 26.5 上验证：登录、游戏库，以及一个真实 D3D11（Unity）游戏通过 DXMT 分支在游戏内渲染。完整接线见 `docs/STEAM-GAMES.md`（`scripts/setup-steam-games.sh`）。注意：在 Steam 里打字时把 macOS 输入法切到英文（ABC），否则输入法合成会显示为 `?`。
+
+**前提条件**：Apple Silicon Mac、Rosetta 2、Xcode 命令行工具、Homebrew、你自己的战网账号/游戏，以及一个用于下载 GPTK 的免费 Apple ID。本仓库不再分发 Apple、Blizzard 或 CodeWeavers 的任何文件。
+
+### 为什么必须要 GPTK？
+
+`libd3dshared.dylib`（GPTK 内）不只是图形库：D2R 的加载器需要它的*非原生代码区域注册*才能通过 Rosetta 2。没有它，即使已开启 AVX 广播，游戏也会在启动时卡死。图形本身可以在没有 D3DMetal 时用纯开源的 vkd3d/MoltenVK 运行。
+
+### 疑难解答
+
+先跑一遍 `soju doctor`：它会检查下面大部分条目并直接指出问题。
+
+- **弹出 "Wine Mono Installer"** -> 跳过了第 2 步；运行 `get-components.sh` 后重新 `build-engine.sh`。
+- **游戏卡在约 86 MB 内存、0% CPU** -> `ROSETTA_ADVERTISE_AVX=1` 或 `libd3dshared` 没有传到游戏。只通过 `play.sh` 启动，并检查第 4 步。
+- **找不到库（gnutls/freetype 报错）** -> 你通过 `nohup`/`arch`/其他 Apple 签名的二进制启动了 wine，`DYLD_*` 变量被剥掉了。请通过 `play.sh` 启动。
+- **战网登录 webview 偶尔闪烁（约一分钟一次）** -> 已知的外观问题；会自动恢复，不影响登录。
+- **虚幻引擎游戏启动时提示 "The installed version of the AMD graphics driver has known issues"**（《霍格沃茨之遗》等）：D3DMetal 把自己伪装成旧驱动版本的 AMD 显卡，触发了 UE4 的驱动检查。无害，点确定即可；想彻底关掉就在游戏的用户 `Engine.ini`（`AppData/Local/<游戏>/Saved/Config/WindowsNoEditor/` 下）加入 `[SystemSettings]` / `r.WarnOfBadDrivers=0`。
+- **GOG GALAXY：通知弹出时右下角出现黑色矩形**，随通知一起消失。通知是 GOG 通知渲染器的透明分层窗口；没有 DWM 合成时 Wine 会把透明区域涂黑。无害。在 GOG 设置里关闭桌面通知即可避免。
+- **BLZBNTBNA00000005** -> `play.sh` 会自动播种签名 exe；请确认是通过它启动的。
+
+### 残留的 Wine 进程
+
+每次启动 bottle 都会附带一组空闲的 Windows 服务进程（`services.exe`、`winedevice.exe`、`plugplay.exe`、`rpcss.exe`、`explorer.exe /desktop`，每组约 100 MB）。如果 bottle 的 `wineserver` 被强杀（崩溃、中断的运行），这些服务不会察觉，会一直挂着。`scripts/soju-sweep.sh` 负责清掉它们，`play.sh kill` / `epic-kill` / `steam-kill` 和守护进程会自动调用。它只在完全没有 `wineserver` 运行时才动手，正在运行的游戏或登录器绝不会被误伤。
+
+## 仓库里有什么
+
+- `scripts/build-engine.sh`：完整的引擎构建配方（freetype 交叉构建、gnutls 接线、GPTK 布局、entitlements）
+- `scripts/setup-bottle.sh` / `scripts/play.sh`：bottle 创建和验证过的启动环境
+- `docs/DIAGNOSIS.md`：CEF 渲染进程崩溃与 Agent 签名失败的深度分析
+- `docs/D2R-GAME-LAUNCH.md`：D2R 加载器调查全记录，包括死胡同
+- `research/`：结论对应的原始日志证据
+
+## 许可
+
+- 本仓库的脚本和文档：**GPL-3.0**（见 LICENSE）
+- 引擎构建自 CodeWeavers 公开的 Wine 源码（GPL/LGPL）。来源：`media.codeweavers.com/pub/crossover/source/`
+- **不包含且永远不会包含**：Apple D3DMetal/GPTK 二进制（禁止再分发）、CrossOver 应用二进制、任何 Blizzard 文件
+- 本项目与 CodeWeavers、Apple、Blizzard Entertainment 均无关联。Battle.net 和 Diablo 是 Blizzard Entertainment 的商标。使用风险自负；使用第三方兼容层进行在线游戏请自行斟酌。

--- a/install.sh
+++ b/install.sh
@@ -38,6 +38,8 @@ else
   mkdir -p "$ENGINE"
   tar -xJf "$BASE/engine.tar.xz" -C "$ENGINE"
   rm -f "$BASE/engine.tar.xz"
+  TAG=$(echo "$URL" | sed -n 's#.*/download/\([^/]*\)/.*#\1#p')
+  [ -n "$TAG" ] && printf '%s\n' "$TAG" > "$ENGINE/.soju-engine-release"
   DYLD_FALLBACK_LIBRARY_PATH="$ENGINE/lib:/usr/lib" "$ENGINE/bin/wine" --version >/dev/null \
     && echo "Engine OK: $(DYLD_FALLBACK_LIBRARY_PATH="$ENGINE/lib:/usr/lib" "$ENGINE/bin/wine" --version)"
 fi

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# soju doctor: check the whole stack and print what is wrong. Read-only.
+# Paste this output when filing an issue.
+set -uo pipefail
+
+BASE="${SOJU_BASE:-$HOME/.battlenet-macos}"
+ENGINE="${ENGINE:-$BASE/cx26-engine}"
+REPO="BCD1210/soju"
+WINESTABLE="/Applications/Wine Stable.app/Contents/Resources/wine/bin/wine"
+
+nok=0; nwarn=0; nfail=0
+pass(){ printf '  ok    %s\n' "$*"; nok=$((nok+1)); }
+warn(){ printf '  warn  %s\n' "$*"; nwarn=$((nwarn+1)); }
+fail(){ printf '  FAIL  %s\n' "$*"; nfail=$((nfail+1)); }
+info(){ printf '  -     %s\n' "$*"; }
+
+echo "soju doctor"
+
+echo
+echo "System"
+info "macOS $(sw_vers -productVersion) ($(uname -m)), $(sysctl -n machdep.cpu.brand_string 2>/dev/null || echo unknown CPU)"
+[ "$(uname -m)" = "arm64" ] && pass "Apple Silicon" || fail "not Apple Silicon: this stack is arm64-only"
+/usr/bin/pgrep -q oahd && pass "Rosetta 2 running" || fail "Rosetta 2 missing: softwareupdate --install-rosetta"
+xcode-select -p >/dev/null 2>&1 && pass "Xcode Command Line Tools" || warn "Xcode CLT missing: xcode-select --install"
+free_gb=$(df -g "$HOME" | awk 'NR==2 {print $4}')
+if [ "${free_gb:-0}" -lt 20 ]; then warn "only ${free_gb}GB free on the home volume (games are big)"; else pass "${free_gb}GB free disk"; fi
+
+echo
+echo "Engine ($ENGINE)"
+if [ -x "$ENGINE/bin/wine" ]; then
+  v=$(DYLD_FALLBACK_LIBRARY_PATH="$ENGINE/lib:/usr/lib" "$ENGINE/bin/wine" --version 2>/dev/null || true)
+  if [ -n "$v" ]; then pass "wine runs: $v"; else fail "engine present but wine does not start (DYLD problem? reinstall: soju update)"; fi
+  tag=$(cat "$ENGINE/.soju-engine-release" 2>/dev/null || echo "")
+  [ -n "$tag" ] && info "installed engine release: $tag" || info "engine release tag not recorded (installed before v1.2 of the installer)"
+  latest=$(curl -fsSL --max-time 5 "https://api.github.com/repos/$REPO/releases?per_page=30" 2>/dev/null \
+           | grep -o '"tag_name": *"engine-[^"]*"' | head -1 | cut -d'"' -f4 || true)
+  if [ -n "$latest" ]; then
+    if [ "$latest" = "$tag" ]; then pass "engine is the latest release ($latest)"
+    else warn "latest engine release is $latest (run: soju update)"; fi
+  else
+    info "could not reach GitHub to compare engine versions (offline?)"
+  fi
+else
+  fail "engine not installed (run: soju install)"
+fi
+
+echo
+echo "Apple GPTK (D3DMetal)"
+if [ -f "$ENGINE/lib/external/libd3dshared.dylib" ]; then
+  pass "libd3dshared.dylib present"
+  [ -d "$ENGINE/lib/external/D3DMetal.framework" ] && pass "D3DMetal.framework present" \
+    || warn "D3DMetal.framework missing from lib/external (get-gptk.sh installs it)"
+  for f in d3d10 d3d11 d3d12 dxgi; do
+    so="$ENGINE/lib/wine/x86_64-unix/$f.so"
+    if [ -L "$so" ]; then pass "$f.so is a symlink"
+    elif [ -f "$so" ]; then fail "$f.so is a regular file: must be a symlink into lib/external (copying breaks @loader_path); re-run scripts/get-gptk.sh"
+    else warn "$f.so missing"; fi
+  done
+else
+  fail "GPTK not installed: games will not start (run scripts/get-gptk.sh)"
+fi
+
+echo
+echo "Bottles ($BASE)"
+[ -f "$BASE/bottle/drive_c/Program Files (x86)/Battle.net/Battle.net.exe" ] \
+  && pass "Battle.net bottle" || info "Battle.net not installed (soju install)"
+if [ -f "$BASE/steam-bottle/drive_c/Program Files (x86)/Steam/steam.exe" ]; then
+  pass "Steam bottle"
+  [ -x "$WINESTABLE" ] && pass "Homebrew wine-stable present" \
+    || fail "Steam bottle exists but wine-stable is gone: brew install --cask wine-stable"
+else
+  info "Steam not installed (soju steam-install)"
+fi
+[ -f "$BASE/epic-bottle/drive_c/Program Files/Epic Games/Launcher/Portal/Binaries/Win64/EpicGamesLauncher.exe" ] \
+  && pass "Epic Games Launcher bottle" || info "Epic not installed (soju epic-install)"
+[ -f "$BASE/gog-bottle/drive_c/Program Files/GOG Galaxy/GalaxyClient.exe" ] \
+  && pass "GOG GALAXY bottle" || info "GOG not installed (soju gog-install)"
+
+echo
+echo "Processes"
+nsrv=$(pgrep -fc wineserver 2>/dev/null || true); nsrv=${nsrv:-0}
+if [ "$nsrv" -gt 0 ]; then
+  info "$nsrv wineserver(s) running (a launcher or game is open)"
+else
+  if pgrep -f 'services\.exe|winedevice\.exe|plugplay\.exe' >/dev/null 2>&1; then
+    warn "orphaned Wine service processes with no wineserver: run scripts/soju-sweep.sh"
+  else
+    pass "no leftover Wine processes"
+  fi
+fi
+src=$(defaults read ~/Library/Preferences/com.apple.HIToolbox.plist AppleSelectedInputSources 2>/dev/null | grep -o '"KeyboardLayout Name" = [^;]*' | head -1 | cut -d= -f2 | tr -d ' ";')
+[ -n "$src" ] && info "current input source: $src (use English/ABC while in games: IMEs swallow key presses)"
+
+echo
+echo "Summary: $nok ok, $nwarn warn, $nfail fail"
+[ "$nfail" -eq 0 ]

--- a/scripts/soju
+++ b/scripts/soju
@@ -26,6 +26,10 @@ Usage:
   soju steam          Launch Steam
   soju steam-kill     Stop everything in the Steam bottle
 
+  soju doctor         Check the whole stack and print what is wrong
+  soju update         Update the scripts and the prebuilt engine
+  soju uninstall      Remove apps, bottles and the engine (asks per item)
+
 Docs: https://github.com/BCD1210/soju
 EOF
 }
@@ -36,6 +40,9 @@ case "${1:-}" in
   gog-install)    shift; exec bash "$ROOT/scripts/create-gog-bottle.sh" "$@" ;;
   steam-install)  shift; exec bash "$ROOT/scripts/create-steam-bottle.sh" "$@" ;;
   steam-games)    shift; exec bash "$ROOT/scripts/setup-steam-games.sh" "$@" ;;
+  doctor)         shift; exec bash "$ROOT/scripts/doctor.sh" "$@" ;;
+  update)         shift; exec bash "$ROOT/scripts/update.sh" "$@" ;;
+  uninstall)      shift; exec bash "$ROOT/scripts/uninstall.sh" "$@" ;;
   battlenet|d2r|epic|epic-kill|gog|gog-kill|steam|kill|steam-kill)
                   exec bash "$ROOT/scripts/play.sh" "$@" ;;
   -h|--help|help|"") usage ;;

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# soju uninstall: remove what soju created, asking per category.
+#   soju uninstall          interactive
+#   soju uninstall --yes    remove everything without asking
+set -euo pipefail
+
+BASE="${SOJU_BASE:-$HOME/.battlenet-macos}"
+ENGINE="${ENGINE:-$BASE/cx26-engine}"
+TTY=/dev/tty
+YES=0; [ "${1:-}" = "--yes" ] && YES=1
+
+ask(){
+  [ "$YES" = 1 ] && return 0
+  read -r -p "$1 [y/N]: " a < "$TTY" || a=n
+  case "$a" in y|Y|yes) return 0;; *) return 1;; esac
+}
+
+echo "soju uninstall: this removes things soju created. Nothing is touched without a yes."
+
+# 1. Stop everything first (best effort).
+for b in bottle epic-bottle gog-bottle; do
+  [ -d "$BASE/$b" ] && WINEPREFIX="$BASE/$b" DYLD_FALLBACK_LIBRARY_PATH="$ENGINE/lib:/usr/lib" \
+    "$ENGINE/bin/wineserver" -k 2>/dev/null || true
+done
+WS="/Applications/Wine Stable.app/Contents/Resources/wine/bin/wineserver"
+[ -d "$BASE/steam-bottle" ] && [ -x "$WS" ] && WINEPREFIX="$BASE/steam-bottle" "$WS" -k 2>/dev/null || true
+sleep 1
+
+# 2. App bundles.
+apps=()
+for a in "Battle.net" "Steam (Windows)" "Epic Games Launcher" "GOG GALAXY"; do
+  [ -d "$HOME/Applications/$a.app" ] && apps+=("$HOME/Applications/$a.app")
+done
+if [ "${#apps[@]}" -gt 0 ]; then
+  printf 'Apps: %s\n' "${apps[@]}"
+  if ask "Remove these apps?"; then rm -rf "${apps[@]}"; echo "  removed"; fi
+fi
+
+# 3. Bottles (this is where installed games live; can be tens of GB).
+for b in bottle steam-bottle epic-bottle gog-bottle; do
+  d="$BASE/$b"
+  [ -d "$d" ] || continue
+  sz=$(du -sh "$d" 2>/dev/null | cut -f1)
+  if ask "Remove bottle $b ($sz, includes installed games)?"; then rm -rf "$d"; echo "  removed"; fi
+done
+
+# 4. Engine (+ the GPTK payload inside it).
+if [ -d "$ENGINE" ]; then
+  sz=$(du -sh "$ENGINE" 2>/dev/null | cut -f1)
+  if ask "Remove the engine ($sz, includes the GPTK payload; re-downloadable with soju install)?"; then
+    rm -rf "$ENGINE"; echo "  removed"
+  fi
+fi
+
+# 5. The scripts copy made by the one-line installer.
+if [ -d "$BASE/soju" ]; then
+  if ask "Remove the scripts copy at $BASE/soju?"; then rm -rf "$BASE/soju"; echo "  removed"; fi
+fi
+rmdir "$BASE" 2>/dev/null && echo "Removed empty $BASE" || true
+
+cat <<'EOT'
+
+Not removed by this script (they are Homebrew's):
+  brew uninstall soju                    the soju CLI itself, if installed via brew
+  brew uninstall --cask wine-stable      the Steam engine
+  brew uninstall mingw-w64               the wrapper build dependency
+EOT
+echo "Done."

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# soju update: update the scripts and the prebuilt engine in place.
+# GPTK files (lib/external + symlinks) and all bottles are preserved.
+set -euo pipefail
+
+REPO="BCD1210/soju"
+BASE="${SOJU_BASE:-$HOME/.battlenet-macos}"
+ENGINE="${ENGINE:-$BASE/cx26-engine}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TTY=/dev/tty
+
+say(){ printf '\n\033[1m%s\033[0m\n' "$*"; }
+
+# ---------- 1. Scripts ----------
+say "[1/2] Updating the Soju scripts"
+if [ -d "$ROOT/.git" ]; then
+  echo "  git checkout at $ROOT"
+  git -C "$ROOT" pull --ff-only || echo "  git pull failed (local changes?); skipping the scripts update"
+elif [[ "$ROOT" == */Cellar/* ]]; then
+  echo "  installed with Homebrew; update with:  brew update && brew upgrade $REPO/soju"
+else
+  echo "  refreshing the tarball copy at $ROOT"
+  tmp="$ROOT.tmp.$$"
+  mkdir -p "$tmp"
+  if curl -fsSL "https://github.com/$REPO/archive/refs/heads/main.tar.gz" | tar -xz -C "$tmp" --strip-components=1; then
+    rsync -a --delete --exclude '.git' "$tmp/" "$ROOT/" 2>/dev/null || { cp -Rf "$tmp/". "$ROOT/"; }
+    chmod +x "$ROOT"/scripts/*.sh "$ROOT"/scripts/soju 2>/dev/null || true
+    echo "  scripts updated"
+  else
+    echo "  download failed; skipping the scripts update"
+  fi
+  rm -rf "$tmp"
+fi
+
+# ---------- 2. Engine ----------
+say "[2/2] Checking the engine"
+if [ ! -x "$ENGINE/bin/wine" ]; then
+  echo "  no engine at $ENGINE (run: soju install)"; exit 0
+fi
+
+URL=$(curl -fsSL "https://api.github.com/repos/$REPO/releases?per_page=30" \
+      | grep -o '"browser_download_url": *"[^"]*soju-engine[^"]*"' | head -1 | grep -o 'https[^"]*') || true
+[ -n "${URL:-}" ] || { echo "  could not find the engine release asset (offline?)"; exit 1; }
+TAG=$(echo "$URL" | sed -n 's#.*/download/\([^/]*\)/.*#\1#p')
+CUR=$(cat "$ENGINE/.soju-engine-release" 2>/dev/null || echo "")
+
+if [ -n "$CUR" ] && [ "$CUR" = "$TAG" ]; then
+  echo "  engine is up to date ($TAG)"; exit 0
+fi
+if [ -z "$CUR" ]; then
+  echo "  installed engine version is not recorded; latest is $TAG"
+  if [ -e "$TTY" ] && [ -z "${SOJU_UPDATE_ENGINE:-}" ]; then
+    read -r -p "  Re-download the engine to be sure? (~350MB) [Y/n]: " a < "$TTY" || a=n
+    case "$a" in n|N) echo "  keeping the current engine"; exit 0;; esac
+  fi
+else
+  echo "  $CUR -> $TAG"
+fi
+
+echo "  downloading $TAG"
+curl -fL "$URL" -o "$BASE/engine.tar.xz"
+NEW="$ENGINE.new"
+rm -rf "$NEW"; mkdir -p "$NEW"
+tar -xJf "$BASE/engine.tar.xz" -C "$NEW"
+rm -f "$BASE/engine.tar.xz"
+printf '%s\n' "$TAG" > "$NEW/.soju-engine-release"
+
+# Carry the GPTK payload over and restore the symlink layout (real files in
+# lib/external, symlinks in x86_64-unix; copying real files there breaks
+# @loader_path, see the README).
+if [ -f "$ENGINE/lib/external/libd3dshared.dylib" ]; then
+  mkdir -p "$NEW/lib/external"
+  cp -Rf "$ENGINE/lib/external/." "$NEW/lib/external/"
+  ( cd "$NEW/lib/wine/x86_64-unix" \
+    && for f in d3d10.so d3d11.so d3d12.so dxgi.so; do ln -sf ../../external/libd3dshared.dylib "$f"; done )
+fi
+
+if ! DYLD_FALLBACK_LIBRARY_PATH="$NEW/lib:/usr/lib" "$NEW/bin/wine" --version >/dev/null 2>&1; then
+  echo "  new engine does not start; keeping the current one (new copy left at $NEW)"; exit 1
+fi
+
+OLD="$ENGINE.old"
+rm -rf "$OLD"
+mv "$ENGINE" "$OLD"
+mv "$NEW" "$ENGINE"
+rm -rf "$OLD"
+echo "  engine updated to $TAG: $(DYLD_FALLBACK_LIBRARY_PATH="$ENGINE/lib:/usr/lib" "$ENGINE/bin/wine" --version)"


### PR DESCRIPTION
Follow-up to the launcher-selection installer, aimed at the first wave of real installs.

- `soju doctor`: read-only health check for the whole stack (Rosetta, engine, GPTK symlink layout, all four bottles, leftover Wine services). Bug reports can start with its output instead of a back-and-forth.
- `soju update`: refreshes the scripts (git pull / tarball / brew hint depending on how soju was installed) and swaps in the newest engine release while carrying over the GPTK payload and the symlink layout. Bottles are never touched. The installer now records the engine release tag so update can compare.
- `soju uninstall`: per-category removal (apps, each bottle with its size shown, engine, scripts copy), nothing deleted without a yes.
- README.zh.md: Simplified Chinese README, since most of this week's traffic came through a Chinese tweet. Language cross-links in all three READMEs.

Tested:
- doctor runs clean on the working install (16 ok) and correctly flags a missing tag file and leftover service processes.
- update exercised end to end against a sandboxed engine copy (SOJU_BASE/ENGINE overrides): tagged engine-v1.0 -> downloaded engine-v1.3, GPTK payload and d3d*.so symlinks carried over, wine --version passes on the swapped engine, tag file written, no .old/.new leftovers.
- uninstall is syntax-checked and dry-read only.