### PR TITLE
README: "What runs" tables, star nudge in installer and doctor, Discussions

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -12,6 +12,33 @@ CodeWeavers가 GPL로 공개한 소스(Wine 11.0, CrossOver 26.3 소스 드롭)�
 
 *[English README](README.md) · [简体中文说明](README.zh.md)*
 
+## 되는 것
+
+<!-- 스크린샷: docs/images/ 에 PNG(d2r-ingame.png, battlenet-login.png, hogwarts-ingame.png)를 넣고 주석을 푸세요.
+<p align="center">
+  <img src="docs/images/d2r-ingame.png" width="49%" alt="M4 Pro에서 실행 중인 Diablo II: Resurrected">
+  <img src="docs/images/battlenet-login.png" width="49%" alt="Apple Silicon에서 로그인된 Battle.net">
+</p>
+-->
+
+모두 M4 Pro / macOS 26.5에서 검증. 엔진은 하나, 런처마다 보틀 하나.
+
+| 런처 | 로그인 | 게임 설치 | 비고 |
+| --- | :-: | :-: | --- |
+| Battle.net | ✅ | ✅ | Agent 동작, `BLZBNTBNA00000005`는 서명 exe 시딩으로 해결 |
+| Epic Games Launcher | ✅ | ✅ | 창을 닫으면 메뉴바 트레이로 |
+| GOG GALAXY | ✅ | ✅ | 로그인·라이브러리까지, 게임은 아직 폭넓게 테스트 안 됨 |
+| Steam (Windows 클라이언트) | ✅ | ✅ | 별도 `wine-stable` + DXMT 보틀 |
+
+| 게임 | 스토어 | 그래픽 | 상태 | 비고 |
+| --- | --- | --- | :-: | --- |
+| Diablo II: Resurrected | Battle.net | D3DMetal (D3D11) | ✅ 인게임, 온라인 | `play.sh`가 `ROSETTA_ADVERTISE_AVX=1` 설정; [가이드](https://bcd1210.github.io/soju/guides/ko/diablo-2-mac.html) |
+| Hogwarts Legacy | Epic | D3DMetal (D3D12) | ✅ 인게임 | UE4 "AMD 드라이버" 경고는 무해, 입력 소스를 영어로 |
+| Unity D3D11 타이틀 | Steam | DXMT | ✅ 인게임, 창 모드 | `soju steam-games` 필요, [docs/STEAM-GAMES.md](docs/STEAM-GAMES.md) |
+| Diablo II: Resurrected (Infernal Edition) | Steam | — | ⏳ 미검증 | Steam 보틀에는 GPTK가 없고 D2R 로더는 `libd3dshared`가 필요 |
+
+안 되는 것: 커널 안티치트(EAC, BattlEye, Vanguard)가 붙은 게임 전부. 다른 게임을 돌리셨다면 [Discussions](https://github.com/BCD1210/soju/discussions)에 올리거나 표에 한 줄 추가하는 PR을 보내주세요.
+
 ## 핵심 발견 3가지
 
 커뮤니티가 몇 달째 못 풀던 문제들의 해법:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,33 @@ Built from CodeWeavers' published GPL sources (Wine 11.0, CrossOver 26.3 source 
 
 *[한국어 README](README.ko.md) · [简体中文说明](README.zh.md)*
 
+## What runs
+
+<!-- Screenshots: drop PNGs into docs/images/ (d2r-ingame.png, battlenet-login.png, hogwarts-ingame.png) and uncomment.
+<p align="center">
+  <img src="docs/images/d2r-ingame.png" width="49%" alt="Diablo II: Resurrected in-game on an M4 Pro">
+  <img src="docs/images/battlenet-login.png" width="49%" alt="Battle.net logged in on Apple Silicon">
+</p>
+-->
+
+All verified on an M4 Pro running macOS 26.5. Same engine, one bottle per launcher.
+
+| Launcher | Login | Install games | Notes |
+| --- | :-: | :-: | --- |
+| Battle.net | ✅ | ✅ | Agent works; `BLZBNTBNA00000005` fixed by the caller-signature seed |
+| Epic Games Launcher | ✅ | ✅ | parks in the menu bar tray on close |
+| GOG GALAXY | ✅ | ✅ | login + library; games not broadly tested yet |
+| Steam (Windows client) | ✅ | ✅ | separate `wine-stable` + DXMT bottle |
+
+| Game | Store | Graphics | Status | Notes |
+| --- | --- | --- | :-: | --- |
+| Diablo II: Resurrected | Battle.net | D3DMetal (D3D11) | ✅ in-game, online | `play.sh` sets `ROSETTA_ADVERTISE_AVX=1`; [guide](https://bcd1210.github.io/soju/guides/diablo-2-resurrected-apple-silicon.html) |
+| Hogwarts Legacy | Epic | D3DMetal (D3D12) | ✅ in-game | UE4 "AMD driver" warning is harmless; switch input source to English |
+| Unity D3D11 title | Steam | DXMT | ✅ in-game, windowed | via `soju steam-games`; see [docs/STEAM-GAMES.md](docs/STEAM-GAMES.md) |
+| Diablo II: Resurrected (Infernal Edition) | Steam | — | ⏳ not verified yet | the Steam bottle has no GPTK, and D2R's loader needs `libd3dshared` |
+
+Will not run: anything with kernel anti-cheat (EAC, BattlEye, Vanguard). Got another game running? Post it in [Discussions](https://github.com/BCD1210/soju/discussions) or send a PR that adds a row.
+
 ## Why this exists
 
 Community Wine builds (Whisky, Kegworks-era engines) stopped working with modern Battle.net and D2R. The commercial option works, but the underlying Wine engine is GPL, so we built it ourselves and documented every wall we hit. Three of those walls had never been publicly solved:

--- a/README.zh.md
+++ b/README.zh.md
@@ -12,6 +12,33 @@
 
 *[English README](README.md) · [한국어 README](README.ko.md)*
 
+## 能跑什么
+
+<!-- 截图：把 PNG（d2r-ingame.png、battlenet-login.png、hogwarts-ingame.png）放进 docs/images/ 后取消注释。
+<p align="center">
+  <img src="docs/images/d2r-ingame.png" width="49%" alt="M4 Pro 上运行的 Diablo II: Resurrected">
+  <img src="docs/images/battlenet-login.png" width="49%" alt="Apple Silicon 上已登录的战网">
+</p>
+-->
+
+均在 M4 Pro / macOS 26.5 上验证。同一个引擎，每个登录器一个独立 bottle。
+
+| 登录器 | 登录 | 安装游戏 | 说明 |
+| --- | :-: | :-: | --- |
+| 战网（Battle.net） | ✅ | ✅ | Agent 正常；`BLZBNTBNA00000005` 通过签名 exe 播种解决 |
+| Epic Games Launcher | ✅ | ✅ | 关闭窗口后驻留菜单栏托盘 |
+| GOG GALAXY | ✅ | ✅ | 登录和游戏库可用；游戏尚未广泛测试 |
+| Steam（Windows 客户端） | ✅ | ✅ | 独立的 `wine-stable` + DXMT bottle |
+
+| 游戏 | 平台 | 图形 | 状态 | 说明 |
+| --- | --- | --- | :-: | --- |
+| Diablo II: Resurrected | 战网 | D3DMetal (D3D11) | ✅ 进入游戏，可联网 | `play.sh` 设置 `ROSETTA_ADVERTISE_AVX=1`；[指南](https://bcd1210.github.io/soju/guides/diablo-2-resurrected-apple-silicon.html) |
+| Hogwarts Legacy | Epic | D3DMetal (D3D12) | ✅ 进入游戏 | UE4 的"AMD 驱动"警告无害；输入法切到英文 |
+| Unity D3D11 游戏 | Steam | DXMT | ✅ 进入游戏，窗口模式 | 需要 `soju steam-games`，见 [docs/STEAM-GAMES.md](docs/STEAM-GAMES.md) |
+| Diablo II: Resurrected（Infernal Edition） | Steam | — | ⏳ 尚未验证 | Steam bottle 没有 GPTK，而 D2R 的加载器需要 `libd3dshared` |
+
+跑不了的：任何带内核级反作弊（EAC、BattlEye、Vanguard）的游戏。跑通了别的游戏？欢迎发到 [Discussions](https://github.com/BCD1210/soju/discussions)，或提 PR 加一行。
+
 ## 为什么会有这个项目
 
 社区 Wine 构建（Whisky、Kegworks 时代的引擎）已经无法运行新版战网和 D2R。商业方案可以用，但其底层 Wine 引擎是 GPL 的，所以我们自己把它编译出来，并记录了撞上的每一堵墙。其中三堵墙此前没有公开解法：

--- a/install.sh
+++ b/install.sh
@@ -201,3 +201,6 @@ done
 say "Done! 🍶  Double-click the app(s) above, log in, install and play."
 echo "Command line: $SOJU_DIR/scripts/soju  (battlenet | d2r | steam | epic | gog, plus *-kill)"
 GPTK_OK || echo "NOTE: GPTK was skipped - run scripts/get-gptk.sh before launching a game."
+echo
+echo "Something broke?  Run 'soju doctor' and paste its output in an issue: https://github.com/BCD1210/soju/issues"
+echo "Worked for you?   A star helps other Mac gamers find this:           https://github.com/BCD1210/soju"

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -93,4 +93,9 @@ src=$(defaults read ~/Library/Preferences/com.apple.HIToolbox.plist AppleSelecte
 
 echo
 echo "Summary: $nok ok, $nwarn warn, $nfail fail"
+if [ "$nfail" -gt 0 ]; then
+  echo "Paste this whole output in a new issue: https://github.com/$REPO/issues/new"
+else
+  echo "All good. If Soju works for you, a star helps other Mac gamers find it: https://github.com/$REPO"
+fi
 [ "$nfail" -eq 0 ]

--- a/scripts/soju
+++ b/scripts/soju
@@ -6,7 +6,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 usage() {
   cat <<'EOF'
-soju: free Battle.net / Diablo II: Resurrected / Epic / Steam on Apple Silicon
+soju: free Battle.net / Diablo II: Resurrected / Epic / GOG / Steam on Apple Silicon
 
 Usage:
   soju install        Set up the Wine engine, Apple GPTK and Battle.net


### PR DESCRIPTION
Unique clones outnumber stars by a wide margin: people install through the one-line curl and never see the repository page. This adds:

- A "What runs" section at the top of all three READMEs: a launcher table (login / install games) and a game table (D2R, Hogwarts Legacy, a Steam Unity title verified; Steam D2R Infernal Edition marked not yet verified), with an anti-cheat caveat and a pointer to Discussions for "got another game running" reports. Screenshot slots are left as an HTML comment until captures exist in `docs/images/`.
- The installer and `soju doctor` end with the repository link: the issue link on failure, a star ask on success.
- GitHub Discussions enabled; `soju` usage line mentions GOG.

https://claude.ai/code/session_01E3HkyBrscwfwEUQBCX5BJW
