### PR TITLE
gptk: install Apple's PE shims too; source-built engines crashed the Epic launcher without them

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -44,7 +44,7 @@ CodeWeavers가 GPL로 공개한 소스(Wine 11.0, CrossOver 26.3 소스 드롭)�
 커뮤니티가 몇 달째 못 풀던 문제들의 해법:
 
 1. **`ROSETTA_ADVERTISE_AVX=1`**: D2R 로더는 AVX 명령어가 필수입니다. 이 환경변수가 없으면 게임이 그래픽 초기화 전에 86MB/0%CPU로 영원히 멈춥니다. "맥에서 D2R이 실행 안 됨"의 정체입니다.
-2. **D3DMetal 심링크 레이아웃**: 애플 GPTK 라이브러리는 `lib/external/`에 실물을 두고, `lib/wine/x86_64-unix/`의 d3d10/11/12/dxgi.so는 **심링크**여야 합니다. 복사하면 `@loader_path`가 어긋나 assertion 루프로 죽습니다.
+2. **D3DMetal 페이로드 레이아웃**: 애플 GPTK 페이로드는 세 부분이고 셋이 다 있어야 D3DMetal이 붙습니다. `lib/external/`(libd3dshared + D3DMetal.framework), Wine 자체 DLL을 대체하는 애플의 PE shim `d3d11.dll`·`d3d12.dll`·`dxgi.dll`(+ `atidxx64`, `nvapi64`, `nvngx`)을 `lib/wine/x86_64-windows/`에, 그리고 shim마다 `lib/wine/x86_64-unix/<shim>.so`를 `lib/external/`로 가는 **심링크**로. 실물을 복사하면 `@loader_path`가 어긋나 assertion 루프로 죽고, Wine 자체 `d3d11.dll`을 그대로 두면 D3D가 wined3d로 돌아가며 Epic Games Launcher는 시작 직후 크래시합니다. `soju gptk`가 세 부분을 모두 설치합니다.
 3. **Battle.net Agent 서명검증 수정**: Agent는 접속한 클라이언트의 서명을 자기 작업폴더(버전 하위폴더) 기준 상대 파일명으로 검사합니다. 서명된 `Battle.net.exe` 사본을 각 `Battle.net.NNNNN` 폴더에 넣으면 통과합니다 (에러 `BLZBNTBNA00000005` 해결).
 
 함정 하나: 실행 체인에 애플 보호 바이너리(`nohup`, `arch` 등)를 두면 macOS가 `DYLD_*` 변수를 제거해 라이브러리를 못 찾습니다.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Community Wine builds (Whisky, Kegworks-era engines) stopped working with modern
 
 1. **`ROSETTA_ADVERTISE_AVX=1`**: D2R's loader requires AVX instructions. Without this env var, the game freezes forever at ~86 MB RSS with 0% CPU, before any graphics init. This is why D2R "hangs at launch" on non-CrossOver Wine builds.
 
-2. **D3DMetal symlink layout**: Apple's Game Porting Toolkit libraries must live in `lib/external/` with `lib/wine/x86_64-unix/{d3d10,d3d11,d3d12,dxgi}.so` as **symlinks** into it. Copying the files instead breaks `@loader_path` resolution and D3DMetal dies in an assertion loop.
+2. **D3DMetal payload layout**: Apple's Game Porting Toolkit payload is three parts, and D3DMetal engages only with all three: `lib/external/` (libd3dshared + D3DMetal.framework), Apple's PE shims `d3d11.dll`, `d3d12.dll`, `dxgi.dll` (plus `atidxx64`, `nvapi64`, `nvngx`) replacing Wine's own in `lib/wine/x86_64-windows/`, and one `lib/wine/x86_64-unix/<shim>.so` per shim as a **symlink** into `lib/external/`. Copying real files there breaks `@loader_path` resolution and D3DMetal dies in an assertion loop; leaving Wine's own `d3d11.dll` in place runs D3D on wined3d instead, and the Epic Games Launcher crashes at start on that. `soju gptk` installs all three parts.
 
 3. **Battle.net Agent caller-signature fix**: the Agent verifies the signature of the connecting client using a relative filename resolved against its CWD (a versioned subfolder). Seeding a copy of the signed `Battle.net.exe` into each `Battle.net.NNNNN` subfolder makes verification pass (fixes error `BLZBNTBNA00000005`).
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -47,7 +47,7 @@
 
 1. **`ROSETTA_ADVERTISE_AVX=1`**：D2R 的加载器要求 AVX 指令集。没有这个环境变量，游戏会在任何图形初始化之前，卡在约 86 MB 内存、0% CPU 的状态永远不动。这就是非 CrossOver 的 Wine 构建上 "D2R 启动即卡死" 的真相。
 
-2. **D3DMetal 符号链接布局**：Apple Game Porting Toolkit 的库必须放在 `lib/external/` 下，而 `lib/wine/x86_64-unix/{d3d10,d3d11,d3d12,dxgi}.so` 必须是指向它的**符号链接**。直接复制文件会破坏 `@loader_path` 解析，D3DMetal 会陷入断言循环。
+2. **D3DMetal 载荷布局**：Apple Game Porting Toolkit 的载荷分三部分，三者齐全 D3DMetal 才会生效：`lib/external/`（libd3dshared + D3DMetal.framework）；Apple 的 PE 垫片 `d3d11.dll`、`d3d12.dll`、`dxgi.dll`（以及 `atidxx64`、`nvapi64`、`nvngx`），放在 `lib/wine/x86_64-windows/` 下替换 Wine 自带的同名 DLL；以及每个垫片对应一个 `lib/wine/x86_64-unix/<垫片>.so`，必须是指向 `lib/external/` 的**符号链接**。直接复制文件会破坏 `@loader_path` 解析，D3DMetal 会陷入断言循环；若保留 Wine 自带的 `d3d11.dll`，D3D 会走 wined3d，Epic Games Launcher 启动即崩溃。`soju gptk` 会安装全部三部分。
 
 3. **战网 Agent 调用方签名修复**：Agent 校验连接客户端的签名时，用的是相对文件名，相对于它自己的工作目录（一个带版本号的子目录）解析。把签名过的 `Battle.net.exe` 复制一份到每个 `Battle.net.NNNNN` 子目录即可通过校验（修复错误 `BLZBNTBNA00000005`）。
 

--- a/docs/DIAGNOSIS.md
+++ b/docs/DIAGNOSIS.md
@@ -418,3 +418,38 @@ wintrust:dump_file_info pcwszFilePath: L"C:/ProgramData/Battle.net/Agent/Agent.e
 
 ### (대안) 근본 wine 패치
 더 깔끔하게는 wine이 프로세스의 윈도우 CWD를 unix cwd와 동기화하거나, `SOFTPUB_OpenFile`이 실패 시 이미지 디렉토리를 탐색하게 패치할 수도 있으나, 파일 seed 방식이 재빌드 없이 견고하므로 채택하지 않음. 리눅스가 문제없는 것도 CWD 해석 차이 때문으로 추정.
+
+## 소스 빌드 엔진에서 Epic 런처가 시작 직후 죽는 이유: GPTK의 PE shim (2026-09-02)
+
+### 증상
+
+패치 4개를 넣고 `build-engine.sh`로 새로 빌드한 엔진(get-gptk.sh로 GPTK 설치)에서 Epic Games
+Launcher가 시작 5초 만에 `EXCEPTION_ACCESS_VIOLATION reading 0x0`으로 죽는다. 같은 보틀, 같은
+런처가 릴리스된 engine-v1.3에서는 멀쩡하다. ncrypt.dll을 이전 것으로 바꿔도 같고, wine stderr에
+`wined3d_adapter_create: Using the Vulkan renderer for d3d10/11 applications`가 찍힌다. 즉 D3DMetal이
+아니라 wined3d가 D3D11을 처리하고 있었다.
+
+### 원인
+
+GPTK 페이로드는 세 부분이다. `external/`(libd3dshared.dylib, D3DMetal.framework),
+`wine/x86_64-windows/`의 PE shim 6개(d3d11, d3d12, dxgi, atidxx64, nvapi64, nvngx: Wine 자체 DLL을
+대체하며 unixlib으로 libd3dshared를 호출한다), `wine/x86_64-unix/`의 shim별 심링크. 스크립트는
+첫 번째와 세 번째만 설치했다. 두 번째가 없으면 Wine 자체 `d3d11.dll`(4.5MB, wined3d)이 그대로
+쓰이고, 심링크는 아무도 안 부른다. Epic 런처(UE)는 그 wined3d 경로에서 NULL을 읽고 죽는다.
+
+그동안 동작한 이유: **릴리스된 engine-v1.0~v1.3 tarball에 그 PE shim 3개(d3d11 114240, d3d12
+122432, dxgi 93760 바이트)가 들어 있었다.** CrossOver의 `lib64/apple_gptk/wine/x86_64-windows/`
+파일과 바이트 단위로 같다. 이 파일들은 Apple 소유라 재배포하면 안 되고, README도 그렇게 적고 있다.
+소스에서 새로 빌드하면 당연히 없다.
+
+### 조치
+
+- `get-gptk.sh`, `install.sh`의 `install_gptk`, `update.sh`의 이관, `install.sh`의 엔진 복구 경로가
+  PE shim을 `<payload>/../wine/x86_64-windows/*.dll`에서 복사하고(Wine 원본은 `.wine`으로 보관),
+  shim마다 심링크를 만든다. `doctor`는 `d3d11.dll`에 Apple의 빌드 경로 문자열
+  (`D3DMetalDLLsBase`)이 있는지로 shim 여부를 판정한다.
+- engine-v1.4부터 tarball은 소스 빌드 그대로다(Wine 자체 d3d DLL, `lib/external` 없음). 이전
+  릴리스의 tarball은 교체해야 한다.
+
+검증: 깨끗한 v1.4 빌드 + `get-gptk.sh`(CrossOver 경로에서 자동 추출) → Epic 로그인 완료, 저장된
+DPoP 키 재사용(NCryptOpenKey → NCryptSignHash), wined3d 폴백 없음, 크래시 없음.

--- a/install.sh
+++ b/install.sh
@@ -24,6 +24,52 @@ say(){ printf '\n\033[1m%s\033[0m\n' "$*"; }
 
 mkdir -p "$BASE"
 
+# ---------- Apple GPTK helpers ----------
+GPTK_OK(){ [ -f "$ENGINE/lib/external/libd3dshared.dylib" ]; }
+find_gptk(){
+  for r in /Volumes/Game* /Volumes/*orting* \
+           "/Applications/CrossOver.app/Contents/SharedSupport/CrossOver/lib64/apple_gptk"; do
+    [ -d "$r" ] || continue
+    f=$(find "$r" -maxdepth 6 -name "libd3dshared.dylib" 2>/dev/null | head -1)
+    [ -n "$f" ] && { dirname "$f"; return 0; }
+  done
+  return 1
+}
+# Three parts, all needed for D3DMetal to engage: external/ (Metal side),
+# wine/x86_64-windows/*.dll (Apple's PE shims replacing Wine's d3d11/d3d12/dxgi),
+# and one unixlib symlink per shim. Same as scripts/get-gptk.sh.
+install_gptk(){
+  local SRC="$1" PE="$1/../wine/x86_64-windows" f b shims
+  mkdir -p "$ENGINE/lib/external"
+  cp -Rf "$SRC/D3DMetal.framework" "$ENGINE/lib/external/" 2>/dev/null || true
+  cp -f  "$SRC/libd3dshared.dylib" "$ENGINE/lib/external/"
+  if [ -d "$PE" ]; then
+    for f in "$PE"/*.dll; do
+      b=$(basename "$f")
+      [ -f "$ENGINE/lib/wine/x86_64-windows/$b" ] && [ ! -f "$ENGINE/lib/wine/x86_64-windows/$b.wine" ] \
+        && cp -p "$ENGINE/lib/wine/x86_64-windows/$b" "$ENGINE/lib/wine/x86_64-windows/$b.wine"
+      cp -f "$f" "$ENGINE/lib/wine/x86_64-windows/$b"
+    done
+    shims=$(cd "$PE" && ls *.dll | sed 's/\.dll$//')
+  else
+    shims="d3d10 d3d11 d3d12 dxgi"
+  fi
+  ( cd "$ENGINE/lib/wine/x86_64-unix" \
+    && for f in $shims; do ln -sf ../../external/libd3dshared.dylib "$f.so"; done )
+}
+# Copy an installed GPTK payload from one engine to another (all three parts).
+carry_gptk(){   # from, to
+  local from="$1" to="$2" f b
+  [ -f "$from/lib/external/libd3dshared.dylib" ] || return 0
+  mkdir -p "$to/lib/external"
+  cp -Rf "$from/lib/external/." "$to/lib/external/"
+  for f in "$from"/lib/wine/x86_64-unix/*.so; do
+    [ -L "$f" ] || continue
+    b=$(basename "$f" .so)
+    [ -f "$from/lib/wine/x86_64-windows/$b.dll" ] && cp -f "$from/lib/wine/x86_64-windows/$b.dll" "$to/lib/wine/x86_64-windows/$b.dll"
+    ln -sf ../../external/libd3dshared.dylib "$to/lib/wine/x86_64-unix/$b.so"
+  done
+}
 # ---------- 1. Engine ----------
 # bin/wine alone can be left behind by an interrupted extract; only an engine
 # that actually starts counts as present.
@@ -46,15 +92,8 @@ else
   TAG=$(echo "$URL" | sed -n 's#.*/download/\([^/]*\)/.*#\1#p')
   printf '%s\n' "${TAG:-unknown}" > "$ENGINE.new/.soju-engine-release"
   if [ -d "$ENGINE" ]; then
-    # A broken engine from an earlier run; keep any GPTK payload in it, and
-    # restore the symlink layout the payload needs (real files in lib/external,
-    # links in x86_64-unix: copies there break @loader_path).
-    if [ -f "$ENGINE/lib/external/libd3dshared.dylib" ]; then
-      mkdir -p "$ENGINE.new/lib/external"
-      cp -Rf "$ENGINE/lib/external/." "$ENGINE.new/lib/external/"
-      ( cd "$ENGINE.new/lib/wine/x86_64-unix" \
-        && for f in d3d10.so d3d11.so d3d12.so dxgi.so; do ln -sf ../../external/libd3dshared.dylib "$f"; done )
-    fi
+    # A broken engine from an earlier run; keep any GPTK payload in it.
+    carry_gptk "$ENGINE" "$ENGINE.new"
     rm -rf "$ENGINE"
   fi
   mv "$ENGINE.new" "$ENGINE"
@@ -64,24 +103,6 @@ else
 fi
 
 # ---------- 2. Apple GPTK ----------
-GPTK_OK(){ [ -f "$ENGINE/lib/external/libd3dshared.dylib" ]; }
-find_gptk(){
-  for r in /Volumes/Game* /Volumes/*orting* \
-           "/Applications/CrossOver.app/Contents/SharedSupport/CrossOver/lib64/apple_gptk"; do
-    [ -d "$r" ] || continue
-    f=$(find "$r" -maxdepth 6 -name "libd3dshared.dylib" 2>/dev/null | head -1)
-    [ -n "$f" ] && { dirname "$f"; return 0; }
-  done
-  return 1
-}
-install_gptk(){
-  local SRC="$1"
-  mkdir -p "$ENGINE/lib/external"
-  cp -Rf "$SRC/D3DMetal.framework" "$ENGINE/lib/external/" 2>/dev/null || true
-  cp -f  "$SRC/libd3dshared.dylib" "$ENGINE/lib/external/"
-  ( cd "$ENGINE/lib/wine/x86_64-unix" \
-    && for f in d3d10.so d3d11.so d3d12.so dxgi.so; do ln -sf ../../external/libd3dshared.dylib "$f"; done )
-}
 if GPTK_OK; then
   say "[2/4] Apple GPTK already installed - skipping"
 else

--- a/install.sh
+++ b/install.sh
@@ -25,7 +25,10 @@ say(){ printf '\n\033[1m%s\033[0m\n' "$*"; }
 mkdir -p "$BASE"
 
 # ---------- Apple GPTK helpers ----------
-GPTK_OK(){ [ -f "$ENGINE/lib/external/libd3dshared.dylib" ]; }
+# Installed means all three parts: the Metal side, and Apple's PE shims in
+# place of Wine's d3d11 (the shim carries Apple's build path string).
+GPTK_OK(){ [ -f "$ENGINE/lib/external/libd3dshared.dylib" ] \
+           && grep -q "D3DMetalDLLsBase" "$ENGINE/lib/wine/x86_64-windows/d3d11.dll" 2>/dev/null; }
 find_gptk(){
   for r in /Volumes/Game* /Volumes/*orting* \
            "/Applications/CrossOver.app/Contents/SharedSupport/CrossOver/lib64/apple_gptk"; do
@@ -66,8 +69,12 @@ carry_gptk(){   # from, to
   for f in "$from"/lib/wine/x86_64-unix/*.so; do
     [ -L "$f" ] || continue
     b=$(basename "$f" .so)
-    [ -f "$from/lib/wine/x86_64-windows/$b.dll" ] && cp -f "$from/lib/wine/x86_64-windows/$b.dll" "$to/lib/wine/x86_64-windows/$b.dll"
-    ln -sf ../../external/libd3dshared.dylib "$to/lib/wine/x86_64-unix/$b.so"
+    # only Apple's shims travel; a Wine DLL next to a symlink is an engine set
+    # up by an older script, and must not be mistaken for one
+    if grep -q "D3DMetalDLLsBase" "$from/lib/wine/x86_64-windows/$b.dll" 2>/dev/null; then
+      cp -f "$from/lib/wine/x86_64-windows/$b.dll" "$to/lib/wine/x86_64-windows/$b.dll"
+      ln -sf ../../external/libd3dshared.dylib "$to/lib/wine/x86_64-unix/$b.so"
+    fi
   done
 }
 # ---------- 1. Engine ----------

--- a/install.sh
+++ b/install.sh
@@ -93,7 +93,7 @@ else
   # The engine ships on its own "engine-*" release, which is not necessarily the
   # newest release: scan all releases and take the first (newest) engine asset.
   URL=$(curl -fsSL "https://api.github.com/repos/$REPO/releases?per_page=30" \
-        | grep -o '"browser_download_url": *"[^"]*soju-engine[^"]*"' | head -1 | grep -o 'https[^"]*')
+        | grep -o '"browser_download_url": *"[^"]*wine-engine[^"]*"' | head -1 | grep -o 'https[^"]*')
   [ -n "$URL" ] || { echo "Could not find the engine release asset."; exit 1; }
   # Download to a .part file and extract into a staging directory, so an
   # interrupted run leaves nothing that a re-run would mistake for done.

--- a/install.sh
+++ b/install.sh
@@ -27,8 +27,14 @@ mkdir -p "$BASE"
 # ---------- Apple GPTK helpers ----------
 # Installed means all three parts: the Metal side, and Apple's PE shims in
 # place of Wine's d3d11 (the shim carries Apple's build path string).
-GPTK_OK(){ [ -f "$ENGINE/lib/external/libd3dshared.dylib" ] \
-           && grep -q "D3DMetalDLLsBase" "$ENGINE/lib/wine/x86_64-windows/d3d11.dll" 2>/dev/null; }
+GPTK_OK(){
+  local f
+  [ -f "$ENGINE/lib/external/libd3dshared.dylib" ] || return 1
+  for f in d3d11 d3d12 dxgi; do
+    grep -q "D3DMetalDLLsBase" "$ENGINE/lib/wine/x86_64-windows/$f.dll" 2>/dev/null || return 1
+    [ -L "$ENGINE/lib/wine/x86_64-unix/$f.so" ] || return 1
+  done
+}
 find_gptk(){
   for r in /Volumes/Game* /Volumes/*orting* \
            "/Applications/CrossOver.app/Contents/SharedSupport/CrossOver/lib64/apple_gptk"; do

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -52,11 +52,15 @@ if [ -f "$ENGINE/lib/external/libd3dshared.dylib" ]; then
   pass "libd3dshared.dylib present"
   [ -d "$ENGINE/lib/external/D3DMetal.framework" ] && pass "D3DMetal.framework present" \
     || warn "D3DMetal.framework missing from lib/external ($SOJU gptk installs it)"
-  for f in d3d10 d3d11 d3d12 dxgi; do
+  for f in d3d11 d3d12 dxgi; do
     so="$ENGINE/lib/wine/x86_64-unix/$f.so"
     if [ -L "$so" ]; then pass "$f.so is a symlink"
     elif [ -f "$so" ]; then fail "$f.so is a regular file: must be a symlink into lib/external (copying breaks @loader_path); re-run: $SOJU gptk"
     else warn "$f.so missing"; fi
+    # Apple's PE shim carries its build path; Wine's own d3d11.dll does not.
+    dll="$ENGINE/lib/wine/x86_64-windows/$f.dll"
+    if [ -f "$dll" ] && grep -q "D3DMetalDLLsBase" "$dll" 2>/dev/null; then pass "$f.dll is the D3DMetal shim"
+    else fail "$f.dll is Wine's own, not Apple's D3DMetal shim: D3D runs on wined3d and the Epic launcher crashes (re-run: $SOJU gptk)"; fi
   done
 else
   fail "GPTK not installed: games will not start (run: $SOJU gptk)"

--- a/scripts/get-gptk.sh
+++ b/scripts/get-gptk.sh
@@ -54,7 +54,28 @@ echo "==> GPTK payload: $SRC"
 mkdir -p "$ENGINE/lib/external"
 cp -Rf "$SRC/D3DMetal.framework" "$ENGINE/lib/external/" 2>/dev/null || true
 cp -f  "$SRC/libd3dshared.dylib" "$ENGINE/lib/external/"
-# Wire the symlinks (never copy! @loader_path rule)
-( cd "$ENGINE/lib/wine/x86_64-unix" && for f in d3d10.so d3d11.so d3d12.so dxgi.so; do ln -sf ../../external/libd3dshared.dylib "$f"; done )
-echo "==> Installed to: $ENGINE/lib/external"
-echo "    (With only libd3dshared and no D3DMetal.framework, games still run on vkd3d graphics)"
+# The payload is three parts, and D3DMetal only engages with all three:
+#   external/               libd3dshared.dylib + D3DMetal.framework (the Metal side)
+#   wine/x86_64-windows/    d3d11.dll, d3d12.dll, dxgi.dll, atidxx64.dll, nvapi64.dll,
+#                           nvngx.dll: Apple's PE shims that replace Wine's own DLLs
+#                           and call into libd3dshared through the unixlib below
+#   wine/x86_64-unix/       one entry per shim, a symlink to libd3dshared
+# With only the first part, Wine keeps its own d3d11.dll (wined3d on Vulkan):
+# slower, and the Epic Games Launcher crashes at start on it.
+PE="$SRC/../wine/x86_64-windows"
+if [ -d "$PE" ]; then
+  for f in "$PE"/*.dll; do
+    b=$(basename "$f")
+    # keep Wine's own copy once, so the swap is reversible
+    [ -f "$ENGINE/lib/wine/x86_64-windows/$b" ] && [ ! -f "$ENGINE/lib/wine/x86_64-windows/$b.wine" ] \
+      && cp -p "$ENGINE/lib/wine/x86_64-windows/$b" "$ENGINE/lib/wine/x86_64-windows/$b.wine"
+    cp -f "$f" "$ENGINE/lib/wine/x86_64-windows/$b"
+  done
+  SHIMS=$(cd "$PE" && ls *.dll | sed 's/\.dll$//')
+else
+  echo "    (no wine/x86_64-windows next to the payload: installing the Metal side only, D3D stays on wined3d)"
+  SHIMS="d3d10 d3d11 d3d12 dxgi"
+fi
+# Wire the unixlib symlinks (never copy! @loader_path rule)
+( cd "$ENGINE/lib/wine/x86_64-unix" && for f in $SHIMS; do ln -sf ../../external/libd3dshared.dylib "$f.so"; done )
+echo "==> Installed to: $ENGINE/lib/external (+ $(echo $SHIMS | wc -w | tr -d ' ') PE shims in lib/wine/x86_64-windows)"

--- a/scripts/play.sh
+++ b/scripts/play.sh
@@ -77,19 +77,26 @@ start_reaper(){
 # remembers the input source per app, so switch to ABC before launching.
 case "$MODE" in *-kill) ;; *) python3 "$(dirname "${BASH_SOURCE[0]}")/soju-input-abc.py" 2>/dev/null || true ;; esac
 
-# Preflight for the CX engine modes: a GPTK payload whose PE shims are missing
-# (an engine refreshed by an older update.sh, which carried only lib/external
-# over) leaves D3D on wined3d, where the Epic launcher crashes at start and
-# games run slowly. Say so instead.
+# Preflight for the CX engine modes: without the GPTK payload, or with a
+# payload whose PE shims are missing (an engine refreshed by an older
+# update.sh, which carried only lib/external over), D3D runs on wined3d: the
+# Epic launcher crashes at start there, D2R's loader needs libd3dshared to get
+# through Rosetta, and everything else is slow. Say so instead of launching.
 case "$MODE" in
   battlenet|d2r|epic|gog)
-    shims_ok(){ local f; for f in d3d11 d3d12 dxgi; do
-      grep -q "D3DMetalDLLsBase" "$ENGINE/lib/wine/x86_64-windows/$f.dll" 2>/dev/null || return 1
-      [ -L "$ENGINE/lib/wine/x86_64-unix/$f.so" ] || return 1; done; }
-    if [ -f "$ENGINE/lib/external/libd3dshared.dylib" ] && ! shims_ok; then
-      echo "soju: this engine has the GPTK payload but not Apple's D3D shims (d3d11/d3d12/dxgi.dll)," >&2
-      echo "      so D3DMetal is not active. Mount the GPTK dmg (or have CrossOver installed) and run:" >&2
-      echo "      $(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/soju gptk" >&2
+    gptk_ok(){ local f
+      [ -f "$ENGINE/lib/external/libd3dshared.dylib" ] || return 1
+      for f in d3d11 d3d12 dxgi; do
+        grep -q "D3DMetalDLLsBase" "$ENGINE/lib/wine/x86_64-windows/$f.dll" 2>/dev/null || return 1
+        [ -L "$ENGINE/lib/wine/x86_64-unix/$f.so" ] || return 1
+      done; }
+    if ! gptk_ok; then
+      if [ -f "$ENGINE/lib/external/libd3dshared.dylib" ]; then
+        echo "soju: this engine has the GPTK payload but not Apple's D3D shims (d3d11/d3d12/dxgi.dll), so D3DMetal is not active." >&2
+      else
+        echo "soju: Apple's Game Porting Toolkit is not installed in this engine, so D3DMetal is not active." >&2
+      fi
+      echo "      Mount the GPTK dmg (or have CrossOver installed) and run:  $(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/soju gptk" >&2
       exit 1
     fi ;;
 esac

--- a/scripts/play.sh
+++ b/scripts/play.sh
@@ -77,6 +77,21 @@ start_reaper(){
 # remembers the input source per app, so switch to ABC before launching.
 case "$MODE" in *-kill) ;; *) python3 "$(dirname "${BASH_SOURCE[0]}")/soju-input-abc.py" 2>/dev/null || true ;; esac
 
+# Preflight for the CX engine modes: a GPTK payload whose PE shims are missing
+# (an engine refreshed by an older update.sh, which carried only lib/external
+# over) leaves D3D on wined3d, where the Epic launcher crashes at start and
+# games run slowly. Say so instead.
+case "$MODE" in
+  battlenet|d2r|epic|gog)
+    if [ -f "$ENGINE/lib/external/libd3dshared.dylib" ] \
+       && ! grep -q "D3DMetalDLLsBase" "$ENGINE/lib/wine/x86_64-windows/d3d11.dll" 2>/dev/null; then
+      echo "soju: this engine has the GPTK payload but not Apple's D3D shims (d3d11/d3d12/dxgi.dll)," >&2
+      echo "      so D3DMetal is not active. Mount the GPTK dmg (or have CrossOver installed) and run:" >&2
+      echo "      $(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/soju gptk" >&2
+      exit 1
+    fi ;;
+esac
+
 case "$MODE" in
   battlenet)   # Battle.net launcher (log in, then Play for online)
     # Battle.net.exe is started directly, not through "Battle.net Launcher.exe":

--- a/scripts/play.sh
+++ b/scripts/play.sh
@@ -83,8 +83,10 @@ case "$MODE" in *-kill) ;; *) python3 "$(dirname "${BASH_SOURCE[0]}")/soju-input
 # games run slowly. Say so instead.
 case "$MODE" in
   battlenet|d2r|epic|gog)
-    if [ -f "$ENGINE/lib/external/libd3dshared.dylib" ] \
-       && ! grep -q "D3DMetalDLLsBase" "$ENGINE/lib/wine/x86_64-windows/d3d11.dll" 2>/dev/null; then
+    shims_ok(){ local f; for f in d3d11 d3d12 dxgi; do
+      grep -q "D3DMetalDLLsBase" "$ENGINE/lib/wine/x86_64-windows/$f.dll" 2>/dev/null || return 1
+      [ -L "$ENGINE/lib/wine/x86_64-unix/$f.so" ] || return 1; done; }
+    if [ -f "$ENGINE/lib/external/libd3dshared.dylib" ] && ! shims_ok; then
       echo "soju: this engine has the GPTK payload but not Apple's D3D shims (d3d11/d3d12/dxgi.dll)," >&2
       echo "      so D3DMetal is not active. Mount the GPTK dmg (or have CrossOver installed) and run:" >&2
       echo "      $(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/soju gptk" >&2

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -96,15 +96,23 @@ printf '%s\n' "$TAG" > "$NEW/.soju-engine-release"
 if [ -f "$ENGINE/lib/external/libd3dshared.dylib" ]; then
   mkdir -p "$NEW/lib/external"
   cp -Rf "$ENGINE/lib/external/." "$NEW/lib/external/"
+  shims=0
   for f in "$ENGINE"/lib/wine/x86_64-unix/*.so; do
     [ -L "$f" ] || continue
     b=$(basename "$f" .so)
-    if [ -f "$ENGINE/lib/wine/x86_64-windows/$b.dll" ]; then
-      [ -f "$NEW/lib/wine/x86_64-windows/$b.dll" ] && cp -p "$NEW/lib/wine/x86_64-windows/$b.dll" "$NEW/lib/wine/x86_64-windows/$b.dll.wine"
-      cp -f "$ENGINE/lib/wine/x86_64-windows/$b.dll" "$NEW/lib/wine/x86_64-windows/$b.dll"
-    fi
+    # Only Apple's shims travel (they carry Apple's build path string). A Wine
+    # DLL beside a symlink is an engine set up by an older get-gptk.sh; copying
+    # it would just move wined3d over.
+    grep -q "D3DMetalDLLsBase" "$ENGINE/lib/wine/x86_64-windows/$b.dll" 2>/dev/null || continue
+    [ -f "$NEW/lib/wine/x86_64-windows/$b.dll" ] && cp -p "$NEW/lib/wine/x86_64-windows/$b.dll" "$NEW/lib/wine/x86_64-windows/$b.dll.wine"
+    cp -f "$ENGINE/lib/wine/x86_64-windows/$b.dll" "$NEW/lib/wine/x86_64-windows/$b.dll"
     ln -sf ../../external/libd3dshared.dylib "$NEW/lib/wine/x86_64-unix/$b.so"
+    shims=$((shims + 1))
   done
+  if [ "$shims" -eq 0 ]; then
+    echo "  NOTE: the old engine had the GPTK Metal side but not Apple's D3D shims, so D3DMetal was not"
+    echo "        active. Mount the GPTK dmg (or have CrossOver installed) and run:  soju gptk"
+  fi
 fi
 
 if ! DYLD_FALLBACK_LIBRARY_PATH="$NEW/lib:/usr/lib" "$NEW/bin/wine" --version >/dev/null 2>&1; then

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -80,14 +80,22 @@ tar -xJf "$BASE/engine.tar.xz" -C "$NEW"
 rm -f "$BASE/engine.tar.xz"
 printf '%s\n' "$TAG" > "$NEW/.soju-engine-release"
 
-# Carry the GPTK payload over and restore the symlink layout (real files in
-# lib/external, symlinks in x86_64-unix; copying real files there breaks
-# @loader_path, see the README).
+# Carry the GPTK payload over: lib/external, Apple's PE shims in
+# x86_64-windows (d3d11/d3d12/dxgi/...: without them Wine's own d3d11 runs on
+# wined3d and the Epic launcher crashes at start), and one unixlib symlink per
+# shim (symlinks, never copies: copying breaks @loader_path).
 if [ -f "$ENGINE/lib/external/libd3dshared.dylib" ]; then
   mkdir -p "$NEW/lib/external"
   cp -Rf "$ENGINE/lib/external/." "$NEW/lib/external/"
-  ( cd "$NEW/lib/wine/x86_64-unix" \
-    && for f in d3d10.so d3d11.so d3d12.so dxgi.so; do ln -sf ../../external/libd3dshared.dylib "$f"; done )
+  for f in "$ENGINE"/lib/wine/x86_64-unix/*.so; do
+    [ -L "$f" ] || continue
+    b=$(basename "$f" .so)
+    if [ -f "$ENGINE/lib/wine/x86_64-windows/$b.dll" ]; then
+      [ -f "$NEW/lib/wine/x86_64-windows/$b.dll" ] && cp -p "$NEW/lib/wine/x86_64-windows/$b.dll" "$NEW/lib/wine/x86_64-windows/$b.dll.wine"
+      cp -f "$ENGINE/lib/wine/x86_64-windows/$b.dll" "$NEW/lib/wine/x86_64-windows/$b.dll"
+    fi
+    ln -sf ../../external/libd3dshared.dylib "$NEW/lib/wine/x86_64-unix/$b.so"
+  done
 fi
 
 if ! DYLD_FALLBACK_LIBRARY_PATH="$NEW/lib:/usr/lib" "$NEW/bin/wine" --version >/dev/null 2>&1; then

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -12,6 +12,13 @@ TTY=/dev/tty
 say(){ printf '\n\033[1m%s\033[0m\n' "$*"; }
 
 # ---------- 1. Scripts ----------
+# Once the scripts are refreshed, the rest of this run must use the new ones
+# (the engine carry-over in particular changes between versions), so step 1
+# re-executes the fresh update.sh with this marker and skips itself.
+if [ "${1:-}" = "--scripts-updated" ]; then
+  shift
+  say "[1/2] Scripts updated"
+else
 say "[1/2] Updating the Soju scripts"
 if [ -e "$ROOT/.git" ]; then          # a directory, or a file for worktrees/submodules
   echo "  git checkout at $ROOT"
@@ -32,10 +39,12 @@ else
     rm -rf "$ROOT.old"; mv "$ROOT" "$ROOT.old"; mv "$tmp" "$ROOT"; rm -rf "$ROOT.old"
     tmp=""
     echo "  scripts updated"
+    exec bash "$ROOT/scripts/update.sh" --scripts-updated "$@"
   else
     echo "  download failed; skipping the scripts update"
   fi
   [ -n "$tmp" ] && rm -rf "$tmp"
+fi
 fi
 
 # ---------- 2. Engine ----------

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -53,9 +53,15 @@ if [ ! -x "$ENGINE/bin/wine" ]; then
   echo "  no engine at $ENGINE (run: soju install)"; exit 0
 fi
 
+# The asset is named wine-engine-*.tar.xz from engine-v1.4 on. Older
+# updaters looked for soju-engine-* and, after refreshing the scripts, went on
+# to swap the engine with their own carry-over code, which dropped Apple's D3D
+# shims. The rename makes that updater stop at "could not find the engine
+# release asset" instead; the next run uses this script and carries the
+# shims over.
 URL=$(curl -fsSL "https://api.github.com/repos/$REPO/releases?per_page=30" \
-      | grep -o '"browser_download_url": *"[^"]*soju-engine[^"]*"' | head -1 | grep -o 'https[^"]*') || true
-[ -n "${URL:-}" ] || { echo "  could not find the engine release asset (offline?)"; exit 1; }
+      | grep -o '"browser_download_url": *"[^"]*wine-engine[^"]*"' | head -1 | grep -o 'https[^"]*') || true
+[ -n "${URL:-}" ] || { echo "  could not find the engine release asset (offline? If the scripts were just updated, run soju update once more)"; exit 1; }
 TAG=$(echo "$URL" | sed -n 's#.*/download/\([^/]*\)/.*#\1#p')
 CUR=$(cat "$ENGINE/.soju-engine-release" 2>/dev/null || echo "")
 


### PR DESCRIPTION
Found while building the engine for v1.4 with the four patches: the launcher died at start with a NULL read, and `wined3d_adapter_create: Using the Vulkan renderer` in stderr showed D3DMetal was not engaged at all.

The GPTK payload is three parts, and the scripts installed two. Apple's PE shims (`d3d11.dll`, `d3d12.dll`, `dxgi.dll`, `atidxx64.dll`, `nvapi64.dll`, `nvngx.dll`) replace Wine's own DLLs and call `libd3dshared` through the unixlib symlinks; without them the symlinks are never used. Previous engine tarballs happened to contain the three d3d shims (byte-identical to CrossOver's `apple_gptk` copies), which is why nobody noticed and which also means those tarballs shipped Apple files. The v1.4 tarball is a clean source build.

- `get-gptk.sh`, `install.sh` (`install_gptk`, engine repair) and `update.sh` copy the shims from `<payload>/../wine/x86_64-windows`, keep Wine's originals as `.wine`, and link every shim.
- `doctor` checks `d3d11/d3d12/dxgi.dll` for Apple's build-path string and fails otherwise.
- README key 2 and DIAGNOSIS updated.

Verified on the clean v1.4 build: `get-gptk.sh` from the CrossOver payload, Epic login complete on the persisted DPoP key, no wined3d fallback, doctor green; doctor flags the shim-less engine.

https://claude.ai/code/session_01E3HkyBrscwfwEUQBCX5BJW
