### PR TITLE
reaper: resolve a symlinked prefix before computing the wineserver directory

### DIFF
--- a/docs/DIAGNOSIS.md
+++ b/docs/DIAGNOSIS.md
@@ -453,3 +453,11 @@ GPTK 페이로드는 세 부분이다. `external/`(libd3dshared.dylib, D3DMetal.
 
 검증: 깨끗한 v1.4 빌드 + `get-gptk.sh`(CrossOver 경로에서 자동 추출) → Epic 로그인 완료, 저장된
 DPoP 키 재사용(NCryptOpenKey → NCryptSignHash), wined3d 폴백 없음, 크래시 없음.
+
+### 후속 (2026-09-02): 심볼릭 링크 프리픽스에서 항상 고아 판정
+
+Battle.net 보틀(`~/.battlenet-macos/bottle`)은 Whisky 컨테이너로 가는 심볼릭 링크다. macOS `stat`은
+기본이 lstat이라 `stat -f %Xd-%Xi`가 링크 자체의 inode를 냈고, Wine은 해석된 경로의 inode로 서버
+디렉토리를 만드니 절대 일치하지 않았다. 결과: 이 보틀의 reaper는 서버가 살아 있어도 두 주기 뒤에
+고아로 판정해 D2R과 Battle.net을 죽였다(v1.4 검증 중 "wineserver crashed"로 나타남). `pwd -P`로 해석한
+경로에 `stat -L`을 쓰도록 고쳤다. Epic 보틀(실제 디렉토리)은 영향이 없어서 스크래치 테스트도 통과했었다.

--- a/scripts/soju-reaper.sh
+++ b/scripts/soju-reaper.sh
@@ -76,7 +76,14 @@ esac
 # /private/tmp, so compare against the resolved form as well: with only the
 # /tmp spelling the check never matched, and the reaper killed every launcher
 # 40 s after it started.
-SERVER_DIR="$(/usr/bin/stat -f "/tmp/.wine-$(id -u)/server-%Xd-%Xi" "$PREFIX" 2>/dev/null || true)"
+#
+# Wine names the directory after the *resolved* prefix. A prefix that is a
+# symlink (a bottle kept in another app's container, say) must be resolved
+# first: macOS stat uses lstat by default, and the symlink's own inode never
+# matches, so the reaper would count the live server as gone and reap the
+# bottle 40 s after every start.
+PREFIX_REAL="$(cd "$PREFIX" 2>/dev/null && pwd -P)"
+SERVER_DIR="$(/usr/bin/stat -L -f "/tmp/.wine-$(id -u)/server-%Xd-%Xi" "${PREFIX_REAL:-$PREFIX}" 2>/dev/null || true)"
 SERVER_DIR_REAL="$(cd /tmp 2>/dev/null && pwd -P)${SERVER_DIR#/tmp}"
 
 # Returns 0 alive, 1 gone, 2 unknown (the query itself failed: every


### PR DESCRIPTION
Found while verifying engine-v1.4 on the Battle.net bottle, which is a symlink into a Whisky container: `stat -f %Xd-%Xi` used lstat and produced the link's inode, so `server_alive` never matched and the reaper reaped the live bottle after two rounds. `pwd -P` + `stat -L`. Verified against both live bottles (symlinked and plain): server alive, 15 processes attributed each.

https://claude.ai/code/session_01E3HkyBrscwfwEUQBCX5BJW