### PR TITLE
gptk: find the mounted toolkit via hdiutil, accept a pasted path, accept only Apple-signed payloads

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -89,7 +89,7 @@ scripts/get-components.sh
 scripts/build-engine.sh
 
 # 4. 애플 GPTK 설치 (https://developer.apple.com/games/game-porting-toolkit/ 에서
-#    dmg 다운로드 후 마운트한 상태로:)
+#    "evaluation environment for Windows games" dmg를 받아 마운트한 상태로:)
 scripts/get-gptk.sh
 #    (CrossOver가 설치돼 있으면 거기서 자동 추출)
 

--- a/README.md
+++ b/README.md
@@ -92,8 +92,9 @@ scripts/get-components.sh
 # 3. Build the engine from GPL sources (30-60 min)
 scripts/build-engine.sh
 
-# 4. Install Apple GPTK payload (download the GPTK dmg from
-#    https://developer.apple.com/games/game-porting-toolkit/ , mount it, then:)
+# 4. Install Apple GPTK payload (download the "evaluation environment for Windows
+#    games" dmg from https://developer.apple.com/games/game-porting-toolkit/ ,
+#    mount it, then:)
 scripts/get-gptk.sh
 #    (if you happen to have CrossOver installed, the script auto-extracts from it instead)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -93,7 +93,7 @@ scripts/get-components.sh
 scripts/build-engine.sh
 
 # 4. 安装 Apple GPTK（从 https://developer.apple.com/games/game-porting-toolkit/
-#    下载 GPTK 的 dmg 并挂载，然后：）
+#    下载 "evaluation environment for Windows games" dmg 并挂载，然后：）
 scripts/get-gptk.sh
 #    （如果你恰好装了 CrossOver，脚本会自动从中提取）
 

--- a/install.sh
+++ b/install.sh
@@ -35,13 +35,38 @@ GPTK_OK(){
     [ -L "$ENGINE/lib/wine/x86_64-unix/$f.so" ] || return 1
   done
 }
-find_gptk(){
-  for r in /Volumes/Game* /Volumes/*orting* \
-           "/Applications/CrossOver.app/Contents/SharedSupport/CrossOver/lib64/apple_gptk"; do
-    [ -d "$r" ] || continue
-    f=$(find "$r" -maxdepth 6 -name "libd3dshared.dylib" 2>/dev/null | head -1)
-    [ -n "$f" ] && { dirname "$f"; return 0; }
-  done
+# Where the payload can be: every disk image mounted under /Volumes (Apple's
+# dmg mounts as "Evaluation environment for Windows games N.N", and the name
+# has changed between releases, so hdiutil is asked for the mount points
+# instead of guessing at names), then an installed CrossOver.
+gptk_roots(){
+  hdiutil info 2>/dev/null | awk -F'\t' '$1 ~ /^\/dev\/disk/ && $3 ~ /^\/Volumes\// {print $3}'
+  echo "/Applications/CrossOver.app/Contents/SharedSupport/CrossOver/lib64/apple_gptk"
+}
+# The payload directory (the one holding libd3dshared.dylib) under one root.
+# The file is copied into the engine and loaded into every game, so only a
+# copy carrying Apple's signature is accepted.
+find_payload_in(){
+  local r="$1" f
+  [ -d "$r" ] || return 1
+  f=$(find "$r" -maxdepth 6 -name "libd3dshared.dylib" 2>/dev/null | head -1)
+  [ -n "$f" ] || return 1
+  local auth; auth=$(codesign -dvv "$f" 2>&1 || true)
+  case "$auth" in *"Authority=Apple Root CA"*) ;; *) auth="" ;; esac
+  if [ -z "$auth" ] || ! codesign -v "$f" 2>/dev/null; then
+    echo "  Found $f but it does not carry Apple's signature, not using it" >&2
+    return 1
+  fi
+  dirname "$f"
+}
+find_gptk(){   # [path]: a mounted volume or folder given by the user, else scan
+  local r
+  if [ -n "${1:-}" ]; then find_payload_in "$1"; return; fi
+  while IFS= read -r r; do
+    [ -n "$r" ] && find_payload_in "$r" && return 0
+  done <<EOF
+$(gptk_roots)
+EOF
   return 1
 }
 # Three parts, all needed for D3DMetal to engage: external/ (Metal side),
@@ -128,14 +153,18 @@ else
   Running games needs one Apple file (libd3dshared). Apple forbids redistributing
   it, so you have to download it yourself (a free Apple ID is enough):
     1) Open https://developer.apple.com/games/game-porting-toolkit/
-    2) Download the "Game Porting Toolkit" dmg and double-click it (mount)
+    2) Download the "evaluation environment for Windows games" dmg (that is
+       the Game Porting Toolkit download) and double-click it to mount it
     3) Come back to this window and press Enter
 EOT
     while true; do
-      read -r -p "  Press Enter when ready (or s to skip): " ans < "$TTY" || ans=s
+      read -r -p "  Press Enter when the dmg is mounted, or paste the path of the mounted volume (s to skip): " ans < "$TTY" || ans=s
       [ "$ans" = "s" ] && { echo "  Skipped - the last lines of this installer say how to add it later"; break; }
-      if SRC=$(find_gptk); then install_gptk "$SRC"; echo "  Installed"; break; fi
-      echo "  Not found yet - make sure the dmg is mounted"
+      ans=${ans//\\ / }; ans=${ans%"${ans##*[! ]}"}   # a path dragged into Terminal comes escaped
+      if SRC=$(find_gptk "$ans"); then install_gptk "$SRC"; echo "  Installed from $SRC"; break; fi
+      echo "  Not found yet. Disk images mounted right now:"
+      hdiutil info 2>/dev/null | awk -F'\t' '$1 ~ /^\/dev\/disk/ && $3 ~ /^\/Volumes\// {print "    " $3}'
+      echo "  If the toolkit is mounted under another name, paste its path (you can drag the volume from Finder into this window)."
     done
   fi
 fi

--- a/scripts/get-gptk.sh
+++ b/scripts/get-gptk.sh
@@ -21,15 +21,27 @@ set -euo pipefail
 ENGINE="${ENGINE:-$HOME/.battlenet-macos/cx26-engine}"
 [ -d "$ENGINE/lib" ] || { echo "Engine not found at $ENGINE. Run install.sh (prebuilt) or scripts/build-engine.sh first."; exit 1; }
 
+# The payload directory (the one holding libd3dshared.dylib) under one root.
+# The file is copied into the engine and loaded into every game, so only a
+# copy carrying Apple's signature is accepted.
 find_payload() {
-  local roots=("$@")
-  for r in "${roots[@]}"; do
-    [ -d "$r" ] || continue
-    local f
-    f=$(find "$r" -maxdepth 6 -name "libd3dshared.dylib" 2>/dev/null | head -1)
-    [ -n "$f" ] && { echo "$(dirname "$f")"; return 0; }
-  done
-  return 1
+  local r="$1" f
+  [ -d "$r" ] || return 1
+  f=$(find "$r" -maxdepth 6 -name "libd3dshared.dylib" 2>/dev/null | head -1)
+  [ -n "$f" ] || return 1
+  local auth; auth=$(codesign -dvv "$f" 2>&1 || true)
+  case "$auth" in *"Authority=Apple Root CA"*) ;; *) auth="" ;; esac
+  if [ -z "$auth" ] || ! codesign -v "$f" 2>/dev/null; then
+    echo "Found $f but it does not carry Apple's signature, not using it" >&2
+    return 1
+  fi
+  dirname "$f"
+}
+# Disk images mounted under /Volumes. Apple's dmg mounts as "Evaluation
+# environment for Windows games N.N" and the name has changed between
+# releases, so ask hdiutil for the mount points instead of guessing names.
+mounted_images() {
+  hdiutil info 2>/dev/null | awk -F'\t' '$1 ~ /^\/dev\/disk/ && $3 ~ /^\/Volumes\// {print $3}'
 }
 
 SRC=""
@@ -37,8 +49,11 @@ if [ $# -ge 1 ]; then
   SRC=$(find_payload "$1") || true
 fi
 if [ -z "$SRC" ]; then
-  # Auto-detect a mounted GPTK dmg
-  SRC=$(find_payload /Volumes/Game* /Volumes/*orting* 2>/dev/null) || true
+  while IFS= read -r r; do
+    [ -n "$r" ] && SRC=$(find_payload "$r") && break
+  done <<EOF
+$(mounted_images)
+EOF
 fi
 if [ -z "$SRC" ]; then
   # Extract from an installed CrossOver (fallback path)
@@ -46,7 +61,9 @@ if [ -z "$SRC" ]; then
 fi
 if [ -z "$SRC" ]; then
   echo "Could not find libd3dshared.dylib."
-  echo "Check that the GPTK dmg is mounted, or pass its path as an argument."
+  echo "Disk images mounted right now:"
+  mounted_images | sed 's/^/  /'
+  echo "Mount the Game Porting Toolkit dmg (\"Evaluation environment for Windows games\"), or pass the path of its volume as an argument."
   exit 1
 fi
 


### PR DESCRIPTION
Fixes the report in Discussion #21: "Not found yet - make sure the dmg is mounted" with the toolkit mounted.

## Cause

`install.sh` and `scripts/get-gptk.sh` looked for the payload under `/Volumes/Game*` and `/Volumes/*orting*`. Apple's download mounts as `Evaluation environment for Windows games N.N`, so a mounted toolkit never matched. My own engine got its payload from CrossOver, which is why the dmg path was never exercised.

## Change

- The mount points come from `hdiutil info` (disk images under `/Volumes`), each is searched for `libd3dshared.dylib`, then an installed CrossOver. No volume-name guessing.
- The installer prompt accepts the path of the mounted volume, pasted or dragged from Finder (backslash escapes stripped). When nothing is found it lists the images it saw.
- Only an Apple-signed `libd3dshared.dylib` is accepted (`codesign -v` passes and the chain ends at `Apple Root CA`): the file goes into the engine and into every game process. The check reads codesign's output into a variable; `grep -q` on the pipe made codesign exit on SIGPIPE, which `pipefail` turned into a rejection of every genuine file.
- README (en/ko/zh) names the dmg the way Apple's page does.

## Test

Two images built with `hdiutil create` and mounted together: `Evaluation environment for Windows games 3.0` with an unsigned stand-in, `4.0` with the Apple-signed dylib from my engine.

| case | result |
|---|---|
| scan, both mounted | picks 4.0 |
| explicit path to 3.0 | rejected (signature) |
| dragged path with `\ ` escapes and trailing space | resolves to 4.0 |
| nonexistent path | not found |
| `get-gptk.sh` into a scratch engine | payload copied, 4 unixlib symlinks created |

Not tested against Apple's real GPTK 4 dmg (needs an Apple ID download). If its layout puts `libd3dshared.dylib` deeper than six levels, the pasted-path route still needs the payload folder itself.
