### PR TITLE
gptk: verify every payload file (anchor apple + known shim hashes), one implementation

### DIFF
--- a/docs/DIAGNOSIS.md
+++ b/docs/DIAGNOSIS.md
@@ -265,6 +265,33 @@ override가 적용되는 것은 regsvr32로 확인했다. `SOJU_EPIC_OVERLAY=1`�
 같은 값이 나온다. 게임에서의 확인(한글로 바꿨다 돌아와도 이동·상호작용 정상, 고정 없음)은 플레이로
 본다.
 
+## GPTK 페이로드 검증: 무엇을 어떻게 믿는가 (2026-09-03)
+
+설치기가 Apple의 GPTK dmg에서 복사하는 파일은 전부 모든 게임 프로세스에 로드된다. 어느 볼륨이든
+`libd3dshared.dylib`이 있으면 복사하던 것을(PR #22 이전) 다음처럼 바꿨다(PR #23). 리뷰 지적: 인증서
+이름 문자열 매칭은 검증이 아니고, dylib 하나만 검사하고 옆의 프레임워크·PE dll을 그냥 복사하면 의미가
+없다.
+
+- **Mach-O(libd3dshared.dylib, D3DMetal.framework)**: `codesign --verify --deep --strict -R="anchor apple"`.
+  "anchor apple"은 Apple 자체 루트에 체인이 닿는 서명만 통과시키는 코드 요구조건이라 암호학적으로
+  확인된다. 임의 인증서로 재서명한 사본은 거부된다(실측: ad-hoc 재서명본 거부).
+- **PE shim(d3d11/d3d12/dxgi 등)**: Windows 바이너리라 macOS에 검증기가 없다(Authenticode 블록은 있음).
+  Apple이 실제로 배포한 빌드의 SHA-256 고정 목록으로 검증한다. 목록 출처: Apple 개발자 다운로드의
+  "Evaluation environment for Windows games" 2.1 / 3.0 / 4.0 beta 2 dmg(직접 받아 `hdiutil verify` 후
+  해시), CrossOver 26.3의 `lib64/apple_gptk`(Apple이 CodeWeavers에 공급한 별도 빌드, 해시가 전부 다름).
+  목록에 없으면 복사하지 않고, 필수 3종(d3d11/d3d12/dxgi) 중 하나라도 빠지면 설치를 중단한다.
+  `SOJU_GPTK_UNVERIFIED=1`은 경고를 찍고 강제 설치한다.
+- **순서**: 전부 검증한 뒤에 복사한다. 중간에 실패하면 엔진은 손대지 않은 상태로 남는다(실측: 변조된
+  d3d11.dll로 중단 시 엔진 파일 0개).
+- **dmg 자체는 서명이 없다**(`codesign`: not signed at all). 컨테이너로 한 번에 검증하는 길은 없다.
+- 새 GPTK가 나오면 목록을 늘려야 한다. `soju update`로 스크립트를 받고, 없으면 이슈로 버전을 받는다.
+  Authenticode 검증을 직접 구현하면 이 결합이 풀리지만 설치기에 자체 암호 코드를 넣는 위험이 더 크다고 봤다.
+
+감지도 바뀌었다. 볼륨 이름(`/Volumes/Game*`)을 추측하지 않고 `hdiutil info`가 알려 주는 마운트된 디스크
+이미지를 전부 뒤진다. Apple dmg의 실제 볼륨명은 "Evaluation environment for Windows games N.N"이고
+(Discussion #21에서 사용자가 여기서 막혔다), 내부 구조는 세 버전 모두
+`redist/lib/external/{libd3dshared.dylib,D3DMetal.framework}` + `redist/lib/wine/x86_64-windows/*.dll`이다.
+
 ## 켜둔 런처가 먹통이 되는 이유: wineserver를 잃은 고아 프로세스 (2026-08-31)
 
 ### 증상

--- a/install.sh
+++ b/install.sh
@@ -35,62 +35,6 @@ GPTK_OK(){
     [ -L "$ENGINE/lib/wine/x86_64-unix/$f.so" ] || return 1
   done
 }
-# Where the payload can be: every disk image mounted under /Volumes (Apple's
-# dmg mounts as "Evaluation environment for Windows games N.N", and the name
-# has changed between releases, so hdiutil is asked for the mount points
-# instead of guessing at names), then an installed CrossOver.
-gptk_roots(){
-  hdiutil info 2>/dev/null | awk -F'\t' '$1 ~ /^\/dev\/disk/ && $3 ~ /^\/Volumes\// {print $3}'
-  echo "/Applications/CrossOver.app/Contents/SharedSupport/CrossOver/lib64/apple_gptk"
-}
-# The payload directory (the one holding libd3dshared.dylib) under one root.
-# The file is copied into the engine and loaded into every game, so only a
-# copy carrying Apple's signature is accepted.
-find_payload_in(){
-  local r="$1" f
-  [ -d "$r" ] || return 1
-  f=$(find "$r" -maxdepth 6 -name "libd3dshared.dylib" 2>/dev/null | head -1)
-  [ -n "$f" ] || return 1
-  local auth; auth=$(codesign -dvv "$f" 2>&1 || true)
-  case "$auth" in *"Authority=Apple Root CA"*) ;; *) auth="" ;; esac
-  if [ -z "$auth" ] || ! codesign -v "$f" 2>/dev/null; then
-    echo "  Found $f but it does not carry Apple's signature, not using it" >&2
-    return 1
-  fi
-  dirname "$f"
-}
-find_gptk(){   # [path]: a mounted volume or folder given by the user, else scan
-  local r
-  if [ -n "${1:-}" ]; then find_payload_in "$1"; return; fi
-  while IFS= read -r r; do
-    [ -n "$r" ] && find_payload_in "$r" && return 0
-  done <<EOF
-$(gptk_roots)
-EOF
-  return 1
-}
-# Three parts, all needed for D3DMetal to engage: external/ (Metal side),
-# wine/x86_64-windows/*.dll (Apple's PE shims replacing Wine's d3d11/d3d12/dxgi),
-# and one unixlib symlink per shim. Same as scripts/get-gptk.sh.
-install_gptk(){
-  local SRC="$1" PE="$1/../wine/x86_64-windows" f b shims
-  mkdir -p "$ENGINE/lib/external"
-  cp -Rf "$SRC/D3DMetal.framework" "$ENGINE/lib/external/" 2>/dev/null || true
-  cp -f  "$SRC/libd3dshared.dylib" "$ENGINE/lib/external/"
-  if [ -d "$PE" ]; then
-    for f in "$PE"/*.dll; do
-      b=$(basename "$f")
-      [ -f "$ENGINE/lib/wine/x86_64-windows/$b" ] && [ ! -f "$ENGINE/lib/wine/x86_64-windows/$b.wine" ] \
-        && cp -p "$ENGINE/lib/wine/x86_64-windows/$b" "$ENGINE/lib/wine/x86_64-windows/$b.wine"
-      cp -f "$f" "$ENGINE/lib/wine/x86_64-windows/$b"
-    done
-    shims=$(cd "$PE" && ls *.dll | sed 's/\.dll$//')
-  else
-    shims="d3d10 d3d11 d3d12 dxgi"
-  fi
-  ( cd "$ENGINE/lib/wine/x86_64-unix" \
-    && for f in $shims; do ln -sf ../../external/libd3dshared.dylib "$f.so"; done )
-}
 # Copy an installed GPTK payload from one engine to another (all three parts).
 carry_gptk(){   # from, to
   local from="$1" to="$2" f b
@@ -140,36 +84,7 @@ else
   echo "Engine OK: $v"
 fi
 
-# ---------- 2. Apple GPTK ----------
-if GPTK_OK; then
-  say "[2/4] Apple GPTK already installed - skipping"
-else
-  say "[2/4] Apple Game Porting Toolkit needed (free, one time)"
-  if SRC=$(find_gptk); then
-    echo "Found: $SRC - installing automatically"
-    install_gptk "$SRC"
-  else
-    cat <<'EOT'
-  Running games needs one Apple file (libd3dshared). Apple forbids redistributing
-  it, so you have to download it yourself (a free Apple ID is enough):
-    1) Open https://developer.apple.com/games/game-porting-toolkit/
-    2) Download the "evaluation environment for Windows games" dmg (that is
-       the Game Porting Toolkit download) and double-click it to mount it
-    3) Come back to this window and press Enter
-EOT
-    while true; do
-      read -r -p "  Press Enter when the dmg is mounted, or paste the path of the mounted volume (s to skip): " ans < "$TTY" || ans=s
-      [ "$ans" = "s" ] && { echo "  Skipped - the last lines of this installer say how to add it later"; break; }
-      ans=${ans//\\ / }; ans=${ans%"${ans##*[! ]}"}   # a path dragged into Terminal comes escaped
-      if SRC=$(find_gptk "$ans"); then install_gptk "$SRC"; echo "  Installed from $SRC"; break; fi
-      echo "  Not found yet. Disk images mounted right now:"
-      hdiutil info 2>/dev/null | awk -F'\t' '$1 ~ /^\/dev\/disk/ && $3 ~ /^\/Volumes\// {print "    " $3}'
-      echo "  If the toolkit is mounted under another name, paste its path (you can drag the volume from Finder into this window)."
-    done
-  fi
-fi
-
-# ---------- 3. Launchers ----------
+# ---------- Soju scripts ----------
 # The bottle scripts live in the repo; fetch a copy next to the engine so the
 # one-line installer can use them (a checkout running install.sh uses itself).
 SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd || true)"
@@ -190,6 +105,43 @@ else
 fi
 chmod +x "$SOJU_DIR"/scripts/*.sh "$SOJU_DIR"/scripts/soju 2>/dev/null || true
 
+# ---------- 2. Apple GPTK ----------
+# scripts/get-gptk.sh finds the payload (mounted toolkit dmg, or CrossOver),
+# verifies every file (Apple's signature on the Mach-O parts, known Apple
+# builds for the PE shims) and installs it. See the notes in that script.
+GPTK="$SOJU_DIR/scripts/get-gptk.sh"
+if GPTK_OK; then
+  say "[2/4] Apple GPTK already installed - skipping"
+else
+  say "[2/4] Apple Game Porting Toolkit needed (free, one time)"
+  if SRC=$(ENGINE="$ENGINE" bash "$GPTK" --find); then
+    echo "Found: $SRC - installing"
+    ENGINE="$ENGINE" bash "$GPTK" "$SRC" || echo "  GPTK not installed (see above); the last lines of this installer say how to add it later"
+  else
+    cat <<'EOT'
+  Running games needs one Apple file (libd3dshared). Apple forbids redistributing
+  it, so you have to download it yourself (a free Apple ID is enough):
+    1) Open https://developer.apple.com/games/game-porting-toolkit/
+    2) Download the "evaluation environment for Windows games" dmg (that is
+       the Game Porting Toolkit download) and double-click it to mount it
+    3) Come back to this window and press Enter
+EOT
+    while true; do
+      read -r -p "  Press Enter when the dmg is mounted, or paste the path of the mounted volume (s to skip): " ans < "$TTY" || ans=s
+      [ "$ans" = "s" ] && { echo "  Skipped - the last lines of this installer say how to add it later"; break; }
+      ans=${ans//\\ / }; ans=${ans%"${ans##*[! ]}"}   # a path dragged into Terminal comes escaped
+      if SRC=$(ENGINE="$ENGINE" bash "$GPTK" --find "$ans"); then
+        ENGINE="$ENGINE" bash "$GPTK" "$SRC" || echo "  GPTK not installed (see above); the last lines of this installer say how to add it later"
+        break
+      fi
+      echo "  Not found yet. Disk images mounted right now:"
+      bash "$GPTK" --list-images | sed 's/^/    /'
+      echo "  If the toolkit is mounted under another name, paste its path (you can drag the volume from Finder into this window)."
+    done
+  fi
+fi
+
+# ---------- 3. Launchers ----------
 ALL="battlenet steam epic gog"
 if [ -n "${SOJU_PLATFORMS:-}" ]; then
   PLATFORMS="$(echo "$SOJU_PLATFORMS" | tr ',' ' ')"

--- a/scripts/get-gptk.sh
+++ b/scripts/get-gptk.sh
@@ -1,41 +1,101 @@
 #!/usr/bin/env bash
-# Install libd3dshared + D3DMetal.framework from Apple's Game Porting Toolkit
-# into the engine.
+# Install Apple's Game Porting Toolkit payload (libd3dshared, D3DMetal.framework
+# and Apple's PE shims) into the engine, after verifying every file.
 #
 # Why it's needed: libd3dshared is required for D2R's loader (anti-cheat) to get
 # through Rosetta 2 (it registers non-native code regions). It also provides the
 # graphics backend (D3DMetal). Apple forbids redistributing it, so you download
 # it yourself: a free Apple ID is enough.
 #
-# 1) Download the "Game Porting Toolkit" dmg from
+# 1) Download the "Evaluation environment for Windows games" dmg (that is the
+#    Game Porting Toolkit download) from
 #    https://developer.apple.com/games/game-porting-toolkit/
 #    (requires an Apple ID sign-in, free)
 # 2) With the dmg mounted (or passing a path), run this script:
 #      scripts/get-gptk.sh                  # auto-detect the mounted volume
-#      scripts/get-gptk.sh /path/to/GPTK    # explicit path
+#      scripts/get-gptk.sh /path/to/volume  # explicit path
+#      scripts/get-gptk.sh --find [path]    # only print the payload directory
 #
 # Alternative: if CrossOver (trial included) is installed, it is extracted from
 # there automatically.
+#
+# Verification. Everything copied here ends up loaded into every game process,
+# so nothing is copied unverified:
+#   - libd3dshared.dylib and D3DMetal.framework must satisfy the code
+#     requirement "anchor apple" (signed by Apple itself, checked
+#     cryptographically by codesign, not by reading certificate names).
+#   - The PE shims (d3d11.dll and friends) are Windows binaries, which macOS
+#     cannot verify, so each one must match the SHA-256 of a build Apple has
+#     shipped (list below, gathered from Apple's own dmgs and from CrossOver).
+#     A shim that is not on the list is not installed. A new toolkit release
+#     therefore needs the list extended: run `soju update`, or open an issue
+#     with the version. SOJU_GPTK_UNVERIFIED=1 installs unknown shims anyway,
+#     loudly.
 set -euo pipefail
 
 ENGINE="${ENGINE:-$HOME/.battlenet-macos/cx26-engine}"
-[ -d "$ENGINE/lib" ] || { echo "Engine not found at $ENGINE. Run install.sh (prebuilt) or scripts/build-engine.sh first."; exit 1; }
 
-# The payload directory (the one holding libd3dshared.dylib) under one root.
-# The file is copied into the engine and loaded into every game, so only a
-# copy carrying Apple's signature is accepted.
+# SHA-256 of every PE shim Apple has shipped, by source. Hashes only: the file
+# name does not matter, a renamed or tampered file simply fails to match.
+KNOWN_SHIMS='
+# Evaluation environment for Windows games 2.1 (2025-03)
+3f88284a15b94840fdb674adc358855339635eaf7757d135f71d3cfdad77e8ab d3d10.dll
+13a621833929d7ced7761d0cf9f9b57765345633dfb83161c2735e9cfb57b0f5 d3d11.dll
+dca51fb33c5d79d36dae95131205b96c837db5c2579d0bfd5fcf3d15e887b324 d3d12.dll
+5e1d256b455f744979092f901a0baeb0053ab291f53e0f6b65f5354043b56d57 dxgi.dll
+18995adb10bed163b7f58ab184c747b1ae6447043292d3497a515bc32e5972b5 atidxx64.dll
+# Evaluation environment for Windows games 3.0 (2025-12)
+d316848cc78301829e6031b60c6f558716cdc74c440df72935968160253c03a5 d3d10.dll
+05fa6f700fb5ee5561dc3a46d98f0aed845d4fa8ab274bff1dc604b0b3f6edd1 d3d11.dll
+27dcf69bedb20ed557a83953e356ab2477b688c2a2c631f880b7583f30ff0705 d3d12.dll
+249711d3d786a9b0bb7c3558f36e472ab07ee21b8dbf118e34c975046832f9a2 dxgi.dll
+bd004dd9e41415b0e1395d51a2ded762a02c7731491e74ed6076f3648ae9ea7f atidxx64.dll
+8e1e6cde85551360d7a061a09445500f3c38805651502f3be65049d937c6960c nvapi64.dll
+d7c0df74d9bb4de5e2a3cc357b2309148fd3fdc824fe7941e4d789dbd072ff99 nvngx-on-metalfx.dll
+# Evaluation environment for Windows games 4.0 beta 2 (2026-07)
+14c84a364a1260497f0a5117ef8efd6e228764ab139a67af1127e8bd013c48c7 d3d10.dll
+303b2bb41efa30c890e2e93d39c3d3c565c8557e069eee832f2cb8a37bd4ec26 d3d11.dll
+1b7a02cb37ec6b484e2aaa76b5ec9cbb47e63aeec29dbe087d5d1589a3347cfb d3d12.dll
+522a8b37216afb09e614489d88a74118076f4d7e08d2b289df6a6eb6f3e817af dxgi.dll
+05eedf19e75c6b4c0dce918577aa6ca3fe5da79d04e42145cf66f498fad3556a nvapi64.dll
+f6bc9d77fd1e898fec8c6339d367bd8e0f338992c9c0c66d59b30c6e9e0743e4 nvngx-on-metalfx.dll
+# CrossOver 26.3 (lib64/apple_gptk, the build Apple supplies to CodeWeavers)
+7c2bfeb66b18e3ec10c3ee92c9d42f4e3123692d568d14c831aec1a13aa03f79 d3d11.dll
+bbda1c4e94ee70255c528c5689b28333ca9bece2d755ede7c4197977a534704f d3d12.dll
+1b1f2d80349e043e6c628b515ba6b44478a1209c504e6c9f3dae4a9d1b06d561 dxgi.dll
+c999c40698b7fc23c864165fb1364e6a40a8572469775947845afd42f4dfc9e7 atidxx64.dll
+f073fc2377b305380bcd8c228394e48abe1caf09116e12875cb656774a14b4dc nvapi64.dll
+'
+# The shims D3DMetal cannot work without (the rest are optional extras).
+REQUIRED_SHIMS="d3d11 d3d12 dxgi"
+
+# Signed by Apple itself: codesign checks the signature and the certificate
+# chain against Apple's anchor. --deep covers the framework's nested code.
+verify_apple() {
+  codesign --verify --deep --strict -R="anchor apple" "$1" 2>/dev/null
+}
+shim_known() {
+  local h; h=$(shasum -a 256 "$1" | cut -d' ' -f1)
+  grep -q "^$h " <<<"$KNOWN_SHIMS"
+}
+# The payload directory (the one holding libd3dshared.dylib) under one root,
+# printed only when both Mach-O parts verify.
 find_payload() {
-  local r="$1" f
+  local r="$1" f dir
   [ -d "$r" ] || return 1
   f=$(find "$r" -maxdepth 6 -name "libd3dshared.dylib" 2>/dev/null | head -1)
   [ -n "$f" ] || return 1
-  local auth; auth=$(codesign -dvv "$f" 2>&1 || true)
-  case "$auth" in *"Authority=Apple Root CA"*) ;; *) auth="" ;; esac
-  if [ -z "$auth" ] || ! codesign -v "$f" 2>/dev/null; then
-    echo "Found $f but it does not carry Apple's signature, not using it" >&2
-    return 1
+  dir=$(dirname "$f")
+  if ! verify_apple "$f"; then
+    echo "Found $f but it is not signed by Apple, not using it" >&2; return 1
   fi
-  dirname "$f"
+  if [ ! -d "$dir/D3DMetal.framework" ]; then
+    echo "Found $f but D3DMetal.framework is not next to it, not using it" >&2; return 1
+  fi
+  if ! verify_apple "$dir/D3DMetal.framework"; then
+    echo "Found $dir/D3DMetal.framework but it is not signed by Apple, not using it" >&2; return 1
+  fi
+  echo "$dir"
 }
 # Disk images mounted under /Volumes. Apple's dmg mounts as "Evaluation
 # environment for Windows games N.N" and the name has changed between
@@ -43,34 +103,38 @@ find_payload() {
 mounted_images() {
   hdiutil info 2>/dev/null | awk -F'\t' '$1 ~ /^\/dev\/disk/ && $3 ~ /^\/Volumes\// {print $3}'
 }
-
-SRC=""
-if [ $# -ge 1 ]; then
-  SRC=$(find_payload "$1") || true
-fi
-if [ -z "$SRC" ]; then
+# Every candidate root: an explicit path, else mounted images, then CrossOver.
+find_gptk() {
+  local r
+  if [ -n "${1:-}" ]; then find_payload "$1"; return; fi
   while IFS= read -r r; do
-    [ -n "$r" ] && SRC=$(find_payload "$r") && break
+    [ -n "$r" ] && find_payload "$r" && return 0
   done <<EOF
 $(mounted_images)
 EOF
+  find_payload "/Applications/CrossOver.app/Contents/SharedSupport/CrossOver/lib64/apple_gptk"
+}
+
+MODE=install
+case "${1:-}" in
+  --find) MODE=find; shift ;;
+  --list-images) mounted_images; exit 0 ;;
+esac
+if [ "$MODE" = install ]; then
+  [ -d "$ENGINE/lib" ] || { echo "Engine not found at $ENGINE. Run install.sh (prebuilt) or scripts/build-engine.sh first."; exit 1; }
 fi
-if [ -z "$SRC" ]; then
-  # Extract from an installed CrossOver (fallback path)
-  SRC=$(find_payload "/Applications/CrossOver.app/Contents/SharedSupport/CrossOver/lib64/apple_gptk") || true
-fi
-if [ -z "$SRC" ]; then
-  echo "Could not find libd3dshared.dylib."
+
+if ! SRC=$(find_gptk "${1:-}"); then
+  [ "$MODE" = find ] && exit 1
+  echo "Could not find an Apple-signed GPTK payload (libd3dshared.dylib + D3DMetal.framework)."
   echo "Disk images mounted right now:"
   mounted_images | sed 's/^/  /'
   echo "Mount the Game Porting Toolkit dmg (\"Evaluation environment for Windows games\"), or pass the path of its volume as an argument."
   exit 1
 fi
+if [ "$MODE" = find ]; then echo "$SRC"; exit 0; fi
 
 echo "==> GPTK payload: $SRC"
-mkdir -p "$ENGINE/lib/external"
-cp -Rf "$SRC/D3DMetal.framework" "$ENGINE/lib/external/" 2>/dev/null || true
-cp -f  "$SRC/libd3dshared.dylib" "$ENGINE/lib/external/"
 # The payload is three parts, and D3DMetal only engages with all three:
 #   external/               libd3dshared.dylib + D3DMetal.framework (the Metal side)
 #   wine/x86_64-windows/    d3d11.dll, d3d12.dll, dxgi.dll, atidxx64.dll, nvapi64.dll,
@@ -80,19 +144,43 @@ cp -f  "$SRC/libd3dshared.dylib" "$ENGINE/lib/external/"
 # With only the first part, Wine keeps its own d3d11.dll (wined3d on Vulkan):
 # slower, and the Epic Games Launcher crashes at start on it.
 PE="$SRC/../wine/x86_64-windows"
+SHIMS=""
+SKIPPED=""
 if [ -d "$PE" ]; then
+  # Verify first, copy after: a payload that fails must not leave the engine
+  # half swapped (Apple's dxgi next to Wine's d3d11).
   for f in "$PE"/*.dll; do
+    [ -f "$f" ] || continue
     b=$(basename "$f")
-    # keep Wine's own copy once, so the swap is reversible
-    [ -f "$ENGINE/lib/wine/x86_64-windows/$b" ] && [ ! -f "$ENGINE/lib/wine/x86_64-windows/$b.wine" ] \
-      && cp -p "$ENGINE/lib/wine/x86_64-windows/$b" "$ENGINE/lib/wine/x86_64-windows/$b.wine"
-    cp -f "$f" "$ENGINE/lib/wine/x86_64-windows/$b"
+    if shim_known "$f"; then SHIMS="$SHIMS ${b%.dll}"
+    elif [ "${SOJU_GPTK_UNVERIFIED:-0}" = 1 ]; then
+      echo "    WARNING: $b is not a build on the known list, installing it anyway (SOJU_GPTK_UNVERIFIED=1)"
+      SHIMS="$SHIMS ${b%.dll}"
+    else SKIPPED="$SKIPPED $b"; fi
   done
-  SHIMS=$(cd "$PE" && ls *.dll | sed 's/\.dll$//')
+  [ -n "$SKIPPED" ] && echo "    Not installed (no known Apple build matches their SHA-256):$SKIPPED"
+  for r in $REQUIRED_SHIMS; do
+    case " $SHIMS " in *" $r "*) ;; *)
+      echo "ERROR: $r.dll from this payload is not a build on the known list, so D3DMetal cannot be enabled from it."
+      echo "       A newer toolkit than this script knows? Run 'soju update' and retry, or open an issue with the toolkit version."
+      echo "       SOJU_GPTK_UNVERIFIED=1 installs it unverified; every game loads these files, so do that only for a dmg you downloaded from Apple yourself."
+      exit 1 ;;
+    esac
+  done
+  for b in $SHIMS; do
+    # keep Wine's own copy once, so the swap is reversible
+    [ -f "$ENGINE/lib/wine/x86_64-windows/$b.dll" ] && [ ! -f "$ENGINE/lib/wine/x86_64-windows/$b.dll.wine" ] \
+      && cp -p "$ENGINE/lib/wine/x86_64-windows/$b.dll" "$ENGINE/lib/wine/x86_64-windows/$b.dll.wine"
+    cp -f "$PE/$b.dll" "$ENGINE/lib/wine/x86_64-windows/$b.dll"
+  done
 else
   echo "    (no wine/x86_64-windows next to the payload: installing the Metal side only, D3D stays on wined3d)"
   SHIMS="d3d10 d3d11 d3d12 dxgi"
 fi
+mkdir -p "$ENGINE/lib/external"
+rm -rf "$ENGINE/lib/external/D3DMetal.framework"
+cp -Rf "$SRC/D3DMetal.framework" "$ENGINE/lib/external/"
+cp -f  "$SRC/libd3dshared.dylib" "$ENGINE/lib/external/"
 # Wire the unixlib symlinks (never copy! @loader_path rule)
 ( cd "$ENGINE/lib/wine/x86_64-unix" && for f in $SHIMS; do ln -sf ../../external/libd3dshared.dylib "$f.so"; done )
 echo "==> Installed to: $ENGINE/lib/external (+ $(echo $SHIMS | wc -w | tr -d ' ') PE shims in lib/wine/x86_64-windows)"

--- a/scripts/get-gptk.sh
+++ b/scripts/get-gptk.sh
@@ -35,8 +35,9 @@ set -euo pipefail
 
 ENGINE="${ENGINE:-$HOME/.battlenet-macos/cx26-engine}"
 
-# SHA-256 of every PE shim Apple has shipped, by source. Hashes only: the file
-# name does not matter, a renamed or tampered file simply fails to match.
+# SHA-256 of every PE shim Apple has shipped, by source. A file must match
+# both the hash and the name it was shipped under: the shims are installed by
+# name, so an allowlisted dxgi.dll renamed to d3d11.dll must not pass either.
 KNOWN_SHIMS='
 # Evaluation environment for Windows games 2.1 (2025-03)
 3f88284a15b94840fdb674adc358855339635eaf7757d135f71d3cfdad77e8ab d3d10.dll
@@ -65,6 +66,7 @@ bbda1c4e94ee70255c528c5689b28333ca9bece2d755ede7c4197977a534704f d3d12.dll
 1b1f2d80349e043e6c628b515ba6b44478a1209c504e6c9f3dae4a9d1b06d561 dxgi.dll
 c999c40698b7fc23c864165fb1364e6a40a8572469775947845afd42f4dfc9e7 atidxx64.dll
 f073fc2377b305380bcd8c228394e48abe1caf09116e12875cb656774a14b4dc nvapi64.dll
+d7c0df74d9bb4de5e2a3cc357b2309148fd3fdc824fe7941e4d789dbd072ff99 nvngx.dll
 '
 # The shims D3DMetal cannot work without (the rest are optional extras).
 REQUIRED_SHIMS="d3d11 d3d12 dxgi"
@@ -76,7 +78,7 @@ verify_apple() {
 }
 shim_known() {
   local h; h=$(shasum -a 256 "$1" | cut -d' ' -f1)
-  grep -q "^$h " <<<"$KNOWN_SHIMS"
+  grep -q "^$h $(basename "$1")\$" <<<"$KNOWN_SHIMS"
 }
 # The payload directory (the one holding libd3dshared.dylib) under one root,
 # printed only when both Mach-O parts verify.


### PR DESCRIPTION
Follow-up to #22, addressing both review findings there.

## What was wrong

- The Apple check matched the certificate names in `codesign -dvv` output. Any chain whose CA is named "Apple Root CA" would pass.
- Only `libd3dshared.dylib` was checked; `D3DMetal.framework` and the PE shims beside it were copied as-is.

## Now

- `libd3dshared.dylib` and `D3DMetal.framework`: `codesign --verify --deep --strict -R="anchor apple"`. Cryptographic, against Apple's own root. An ad-hoc re-signed copy is refused.
- PE shims (`d3d11.dll`, `d3d12.dll`, `dxgi.dll`, `atidxx64.dll`, `nvapi64.dll`, `nvngx*.dll`): Windows binaries, no verifier on macOS, so each must match the SHA-256 of a build Apple has shipped. The list in `get-gptk.sh` was built from the "Evaluation environment for Windows games" 2.1, 3.0 and 4.0 beta 2 dmgs (downloaded from Apple, `hdiutil verify`, hashed) and from CrossOver 26.3's `lib64/apple_gptk`, which is a different build. Unknown shim: not installed. Missing `d3d11`/`d3d12`/`dxgi`: abort before any copy. `SOJU_GPTK_UNVERIFIED=1` overrides with a warning.
- Verify everything first, copy after, so a rejected payload leaves the engine untouched.
- `install.sh` fetches the scripts before the GPTK step and calls `scripts/get-gptk.sh --find` / install, instead of carrying a second copy of the detection code.

The dmg itself is unsigned (`codesign`: "not signed at all"), so there is no container-level check to lean on. A new toolkit release needs the hash list extended; `soju update` delivers that. Authenticode verification in the installer would remove that coupling but means custom crypto code in an installer, which I would rather not ship.

## Tests

| case | result |
|---|---|
| 2.1 + 3.0 + 4.0b2 mounted, auto-detect | 2.1 picked (first image); each installs from its own path: 5 / 7 / 6 shims |
| d3d11.dll with one byte changed | refused; 0 files written to the engine |
| same, `SOJU_GPTK_UNVERIFIED=1` | installed with warning |
| libd3dshared.dylib ad-hoc re-signed | refused at detection |
| no image mounted, CrossOver installed | CrossOver payload, 6 shims, all on the list |

`docs/DIAGNOSIS.md` records what is trusted and why.
