### PR TITLE
Position Soju as an open-source game launcher toolkit

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -1,14 +1,21 @@
 # Soju (한국어)
 
-> *Wine → Whisky → Kegworks… 그리고 한국의 차례: **Soju** 🍶*
+> **Apple Silicon 맥용 무료 오픈소스 게임 런처 도구.**
 
-**런처가 실제로 로그인됩니다.** Apple Silicon 맥에서 Battle.net·Steam·Epic Games Launcher·GOG GALAXY. 검은 로그인 창도, 끝나지 않는 "Signing in…"도, CrossOver 라이선스도 없이. 완전 무료 오픈소스 Wine 스택.
+맥에서 **Battle.net·Steam·Epic Games Launcher·GOG GALAXY**를 설치하고 실행하세요.
+Soju는 터미널 설치 도구, 런처별 독립 Wine 환경, 더블클릭으로 실행하는 맥 앱을 제공합니다.
+기존 스토어 계정으로 로그인해 지원되는 Windows 게임을 플레이할 수 있습니다.
 
-Whisky/Kegworks 스레드의 *"배틀넷 로그인 시 크래시"*, *"Steam이 안 열림"*, *"런처 창이 비어 있음"* 때문에 오셨다면, 바로 그 벽들을 이 레포가 기록하고 해결했습니다(CEF 렌더러 `PAGE_WRITECOPY` int3, CEF GPU 프로세스 초기화 사망, Steam webhelper). [docs/DIAGNOSIS.md](docs/DIAGNOSIS.md).
+게임 라이브러리는 각 스토어의 런처에서 이용합니다. 현재 Soju는 CLI와 런처별 실행 앱으로
+구성되어 있으며, 게임과 시스템에 따라 호환성이 달라집니다.
 
-CodeWeavers가 GPL로 공개한 소스(Wine 11.0, CrossOver 26.3 소스 드롭)를 이 레포의 스크립트로 직접 빌드·조립합니다. 유료 소프트웨어 불필요.
+도구는 무료 오픈소스입니다. 기본 Wine 엔진은 CodeWeavers 공개 소스로 빌드하며,
+Steam은 별도의 wine-stable 환경을 사용합니다. Apple의 비공개 GPTK/D3DMetal 구성요소는
+별도로 내려받아야 합니다. 게임과 스토어 클라이언트는 포함하지 않습니다.
 
-> 상태(2026-08): **전 구간 동작**: 배틀넷 로그인·Agent·D2R 인게임 렌더링(D3DMetal), Epic Games Launcher 로그인·게임 설치(메뉴바 트레이), GOG GALAXY 로그인, Steam 로그인 + D3D11 게임. M4 Pro / macOS 26.5에서 검증.
+**현재 스크립트: [v1.3.6](https://github.com/BCD1210/soju/releases/tag/v1.3.6).**
+아래 실행 사례는 M4 Pro / macOS 26.5에서 확인한 결과입니다.
+디아블로2와 호그와트 레거시는 지원 사례이며, 프로젝트의 범위는 여러 게임 런처입니다.
 
 *[English README](README.md) · [简体中文说明](README.zh.md)*
 
@@ -21,7 +28,7 @@ CodeWeavers가 GPL로 공개한 소스(Wine 11.0, CrossOver 26.3 소스 드롭)�
 </p>
 -->
 
-모두 M4 Pro / macOS 26.5에서 검증. 엔진은 하나, 런처마다 보틀 하나.
+모두 M4 Pro / macOS 26.5에서 검증. 런처마다 별도 보틀을 사용하며, Steam은 엔진도 별도입니다.
 
 | 런처 | 로그인 | 게임 설치 | 비고 |
 | --- | :-: | :-: | --- |
@@ -41,7 +48,7 @@ CodeWeavers가 GPL로 공개한 소스(Wine 11.0, CrossOver 26.3 소스 드롭)�
 
 ## 핵심 발견 3가지
 
-커뮤니티가 몇 달째 못 풀던 문제들의 해법:
+설치와 실행을 안정화하면서 확인한 원인과 해결 방법:
 
 1. **`ROSETTA_ADVERTISE_AVX=1`**: D2R 로더는 AVX 명령어가 필수입니다. 이 환경변수가 없으면 게임이 그래픽 초기화 전에 86MB/0%CPU로 영원히 멈춥니다. "맥에서 D2R이 실행 안 됨"의 정체입니다.
 2. **D3DMetal 페이로드 레이아웃**: 애플 GPTK 페이로드는 세 부분이고 셋이 다 있어야 D3DMetal이 붙습니다. `lib/external/`(libd3dshared + D3DMetal.framework), Wine 자체 DLL을 대체하는 애플의 PE shim `d3d11.dll`·`d3d12.dll`·`dxgi.dll`(+ `atidxx64`, `nvapi64`, `nvngx`)을 `lib/wine/x86_64-windows/`에, 그리고 shim마다 `lib/wine/x86_64-unix/<shim>.so`를 `lib/external/`로 가는 **심링크**로. 실물을 복사하면 `@loader_path`가 어긋나 assertion 루프로 죽고, Wine 자체 `d3d11.dll`을 그대로 두면 D3D가 wined3d로 돌아가며 Epic Games Launcher는 시작 직후 크래시합니다. `soju gptk`가 세 부분을 모두 설치합니다.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,22 @@
 # Soju
 
-> *Wine → Whisky → Kegworks… and now a Korean round: **Soju** 🍶*
+> **Free, open-source game launcher toolkit for Apple Silicon Macs.**
 
-**The launchers actually log in.** Battle.net, Steam, the Epic Games Launcher and GOG GALAXY on Apple Silicon. No black login window, no "Signing in…" that never ends, no CrossOver license. A fully free, open-source Wine stack.
+Set up **Battle.net, Steam, Epic Games Launcher and GOG GALAXY** on your Mac.
+Soju provides terminal setup, separate Wine environments and a Mac launch app for
+each store. Sign in to your existing accounts and play supported Windows games.
 
-If you got here from a Whisky/Kegworks thread titled *"Battle.net crashes on login"*, *"Steam won't open"* or *"launcher shows a blank window"*: those are the exact walls this repo documents and fixes (CEF renderer `int3` on `PAGE_WRITECOPY`, CEF GPU process dying on init, Steam's webhelper). See [docs/DIAGNOSIS.md](docs/DIAGNOSIS.md).
+The interface is each store's own launcher; Soju currently ships a CLI and
+launcher-specific shortcuts. Compatibility varies by game and system.
 
-Built from CodeWeavers' published GPL sources (Wine 11.0, CrossOver 26.3 source drop), compiled and assembled by scripts in this repo. No paid software required.
+The tools are free and open source. The main Wine engine is built from
+CodeWeavers' published sources; Steam uses a separate wine-stable setup.
+Apple's proprietary GPTK/D3DMetal is downloaded separately. Games and store
+clients are not included.
 
-> Status (2026-08): **Working end-to-end**: Battle.net login, Agent, and D2R in-game rendering (D3DMetal); Epic Games Launcher login and game installs (tray icon in the menu bar); GOG GALAXY login; Steam client login + D3D11 games. Verified on an M4 Pro running macOS 26.5.
+**Current scripts: [v1.3.6](https://github.com/BCD1210/soju/releases/tag/v1.3.6).**
+The compatibility examples below were verified on M4 Pro / macOS 26.5.
+D2R and Hogwarts Legacy are examples of supported games, not the scope of the project.
 
 *[한국어 README](README.ko.md) · [简体中文说明](README.zh.md)*
 
@@ -21,7 +29,7 @@ Built from CodeWeavers' published GPL sources (Wine 11.0, CrossOver 26.3 source 
 </p>
 -->
 
-All verified on an M4 Pro running macOS 26.5. Same engine, one bottle per launcher.
+All verified on an M4 Pro running macOS 26.5. Separate bottles for each launcher; Steam uses its own engine.
 
 | Launcher | Login | Install games | Notes |
 | --- | :-: | :-: | --- |
@@ -41,7 +49,7 @@ Will not run: anything with kernel anti-cheat (EAC, BattlEye, Vanguard). Got ano
 
 ## Why this exists
 
-Community Wine builds (Whisky, Kegworks-era engines) stopped working with modern Battle.net and D2R. The commercial option works, but the underlying Wine engine is GPL, so we built it ourselves and documented every wall we hit. Three of those walls had never been publicly solved:
+Community Wine builds (Whisky, Kegworks-era engines) stopped working with modern Battle.net and D2R. The commercial option works, but the underlying Wine engine is GPL, so we built it ourselves and documented every wall we hit. The investigation and fixes are documented below:
 
 ### The three keys
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,14 +1,21 @@
 # Soju（简体中文）
 
-> *Wine → Whisky → Kegworks…… 这一轮来自韩国：**Soju** 🍶*
+> **面向 Apple Silicon Mac 的免费开源游戏启动工具。**
 
-**登录器真的能登录。** 在 Apple Silicon Mac 上运行战网（Battle.net）、Steam、Epic Games Launcher 和 GOG GALAXY。没有黑色登录窗口，没有永远转圈的 "Signing in…"，也不需要 CrossOver 许可证。完全免费的开源 Wine 栈。
+在 Mac 上安装和运行 **Battle.net、Steam、Epic Games Launcher 和 GOG GALAXY**。
+Soju 提供终端安装工具、独立的 Wine 环境，以及每个商店对应的 Mac 启动应用。
+使用已有的商店账号登录，运行兼容的 Windows 游戏。
 
-如果你是从 Whisky/Kegworks 相关帖子（"战网登录时崩溃"、"Steam 打不开"、"登录器窗口一片空白"）找到这里的：这些正是本仓库记录并解决的问题（CEF 渲染进程在 `PAGE_WRITECOPY` 上触发 `int3`、CEF GPU 进程初始化即死、Steam 的 webhelper）。详见 [docs/DIAGNOSIS.md](docs/DIAGNOSIS.md)。
+游戏库仍通过各商店自己的客户端访问。Soju 目前提供 CLI 和各启动器的快捷应用；
+兼容性取决于游戏和系统环境。
 
-引擎由 CodeWeavers 公开的 GPL 源码（Wine 11.0，CrossOver 26.3 源码包）用本仓库的脚本编译组装而成。不需要任何付费软件。
+工具免费开源。主 Wine 引擎基于 CodeWeavers 公开源码构建，Steam 使用独立的
+wine-stable 环境。Apple 的专有 GPTK/D3DMetal 组件需要单独下载。
+项目不包含游戏或商店客户端。
 
-> 状态（2026-08）：**全链路可用**：战网登录、Agent、D2R 进入游戏并正常渲染（D3DMetal）；Epic Games Launcher 登录和游戏安装（菜单栏托盘图标）；GOG GALAXY 登录；Steam 客户端登录 + D3D11 游戏。在 M4 Pro / macOS 26.5 上验证。
+**当前脚本版本：[v1.3.6](https://github.com/BCD1210/soju/releases/tag/v1.3.6)。**
+下方运行案例在 M4 Pro / macOS 26.5 上验证。
+D2R 和 Hogwarts Legacy 是兼容案例，项目面向多个游戏启动器。
 
 *[English README](README.md) · [한국어 README](README.ko.md)*
 
@@ -21,7 +28,7 @@
 </p>
 -->
 
-均在 M4 Pro / macOS 26.5 上验证。同一个引擎，每个登录器一个独立 bottle。
+均在 M4 Pro / macOS 26.5 上验证。每个启动器使用独立 bottle；Steam 的引擎也独立。
 
 | 登录器 | 登录 | 安装游戏 | 说明 |
 | --- | :-: | :-: | --- |
@@ -41,7 +48,7 @@
 
 ## 为什么会有这个项目
 
-社区 Wine 构建（Whisky、Kegworks 时代的引擎）已经无法运行新版战网和 D2R。商业方案可以用，但其底层 Wine 引擎是 GPL 的，所以我们自己把它编译出来，并记录了撞上的每一堵墙。其中三堵墙此前没有公开解法：
+社区 Wine 构建（Whisky、Kegworks 时代的引擎）已经无法运行新版战网和 D2R。商业方案可以用，但其底层 Wine 引擎是 GPL 的，所以我们自己把它编译出来，并记录了撞上的每一堵墙。以下记录了其中三个问题的诊断和修复：
 
 ### 三把钥匙
 

--- a/docs/guides/diablo-2-resurrected-apple-silicon.html
+++ b/docs/guides/diablo-2-resurrected-apple-silicon.html
@@ -19,6 +19,7 @@
   <a href="https://github.com/BCD1210/soju">GitHub</a>
 </div></nav>
 <main>
+<p class="note">This guide is part of <a href="../">Soju, the open-source game launcher toolkit for Apple Silicon</a>. Explore Battle.net, Steam, Epic and GOG setup and compatibility on the overview page.</p>
 <h1>Diablo II: Resurrected on Apple Silicon</h1>
 <p class="lead">Why it hangs at launch on M-series Macs, and how to play it
 completely free with an open-source Wine stack. Verified in-game (online, with

--- a/docs/guides/ko/diablo-2-mac.html
+++ b/docs/guides/ko/diablo-2-mac.html
@@ -19,6 +19,7 @@
   <a href="https://github.com/BCD1210/soju">GitHub</a>
 </div></nav>
 <main>
+<p class="note">이 가이드는 <a href="../../">Soju 오픈소스 게임 런처 도구</a>의 사용 사례입니다. Battle.net·Steam·Epic·GOG 설치와 지원 범위는 메인 페이지에서 확인하세요.</p>
 <h1>맥에서 디아블로 II: 레저렉션 돌리기</h1>
 <p class="lead">애플 실리콘 맥(M1~M4)에서 디아2 레저렉션이 "실행이 안 되는" 진짜
 이유와, 크로스오버(연 $74) 없이 완전 무료로 돌리는 방법입니다. M4 Pro / macOS 26에서

--- a/docs/guides/steam-windows-client-apple-silicon.html
+++ b/docs/guides/steam-windows-client-apple-silicon.html
@@ -19,6 +19,7 @@
   <a href="https://github.com/BCD1210/soju">GitHub</a>
 </div></nav>
 <main>
+<p class="note">This guide is part of <a href="../">Soju, the open-source game launcher toolkit for Apple Silicon</a>. Explore Battle.net, Steam, Epic and GOG setup and compatibility on the overview page.</p>
 <h1>The Windows Steam client on Apple Silicon</h1>
 <p class="lead">Yes, the actual Windows Steam client (not just macOS Steam) runs
 on M-series Macs for free, including D3D11 games rendering in-game. Verified on an

--- a/docs/guides/whisky-alternative.html
+++ b/docs/guides/whisky-alternative.html
@@ -19,6 +19,7 @@
   <a href="https://github.com/BCD1210/soju">GitHub</a>
 </div></nav>
 <main>
+<p class="note">This guide is part of <a href="../">Soju, the open-source game launcher toolkit for Apple Silicon</a>. Explore Battle.net, Steam, Epic and GOG setup and compatibility on the overview page.</p>
 <h1>Whisky is gone. What now?</h1>
 <p class="lead">Whisky was the free way to run Windows games on Apple Silicon.
 Development stopped, and its content server (data.getwhisky.app) went offline.

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,87 +3,119 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Soju: Free Battle.net, Steam, Epic &amp; GOG launchers that actually log in on Apple Silicon</title>
-<meta name="description" content="Soju is a free, open-source (GPL) Wine stack where Battle.net, Steam, the Epic Games Launcher and GOG GALAXY actually log in on Apple Silicon Macs. No black login window, no CrossOver license. Diablo II: Resurrected and D3D11 Steam games verified.">
+<title>Soju — Free, open-source game launcher toolkit for Apple Silicon Macs</title>
+<meta name="description" content="Set up Battle.net, Steam, Epic Games Launcher and GOG GALAXY on Apple Silicon with Soju, a free, open-source launcher toolkit. Separate Wine environments, Mac launch shortcuts, and documented fixes.">
 <link rel="canonical" href="https://bcd1210.github.io/soju/">
-<meta property="og:title" content="Soju: free Windows gaming on Apple Silicon">
-<meta property="og:description" content="Battle.net, Steam and Epic Games Launcher logins that work on M-series Macs, fully free and open source.">
+<meta property="og:title" content="Soju — Your Windows launchers, on your Mac">
+<meta property="og:description" content="A free, open-source launcher toolkit for Apple Silicon. Battle.net, Steam, Epic and GOG — with documented setup and compatibility.">
 <meta property="og:type" content="website">
+<meta property="og:url" content="https://bcd1210.github.io/soju/">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="Soju — Open-source game launching for Mac">
+<meta name="twitter:description" content="Set up Battle.net, Steam, Epic and GOG on Apple Silicon. Free launcher tools, separate Wine environments, and tested game examples.">
 <link rel="stylesheet" href="style.css">
 </head>
 <body>
-<nav><div class="inner">
+<nav aria-label="Main navigation"><div class="inner">
   <a class="brand" href="./">🍶 Soju</a>
-  <a href="guides/diablo-2-resurrected-apple-silicon.html">D2R guide</a>
-  <a href="guides/steam-windows-client-apple-silicon.html">Steam guide</a>
-  <a href="guides/whisky-alternative.html">Whisky alternatives</a>
+  <a href="#launchers">Launchers</a>
+  <a href="#install">Install</a>
+  <a href="#compatibility">Compatibility</a>
+  <a href="#guides">Guides</a>
   <a href="https://github.com/BCD1210/soju">GitHub</a>
 </div></nav>
 <main>
-<h1>Free Windows gaming on Apple Silicon</h1>
-<p class="lead">Soju is a free, open-source (GPL-3.0) toolchain that runs Battle.net,
-Diablo&nbsp;II: Resurrected and the Windows Steam client (including D3D11 games)
-on M-series Macs. No CrossOver license needed.</p>
+<header class="hero">
+<p class="eyebrow">FREE &amp; OPEN SOURCE · APPLE SILICON</p>
+<h1>Your Windows launchers.<br>On your Mac.</h1>
+<p class="lead">Soju is an open-source game launcher toolkit for Apple Silicon.
+Set up Battle.net, Steam, Epic Games Launcher and GOG GALAXY, sign in to your
+existing accounts, and play supported Windows games.</p>
+<p>Terminal setup. A separate Mac launch app for each launcher.
+Choose the stores you use; Soju keeps their Wine environments separate.</p>
+<div class="actions"><a class="btn" href="#install">Install Soju</a>
+<a href="https://github.com/BCD1210/soju">Explore the source</a></div>
+</header>
 
-<pre><code>brew install BCD1210/soju/soju
-soju install     # Battle.net + Diablo II: Resurrected
-soju steam-install</code></pre>
-<p>Or without Homebrew:</p>
-<pre><code>curl -fsSL soju.snack-wrap.com/install.sh | bash</code></pre>
-<p><a class="btn" href="https://github.com/BCD1210/soju">View on GitHub</a></p>
-
-<h2>Guides</h2>
-<div class="cards">
-  <a class="card" href="guides/diablo-2-resurrected-apple-silicon.html">
-    <h3>Diablo II: Resurrected on Apple Silicon</h3>
-    <p>Why it hangs at launch (the AVX root cause) and how to play it for free.</p>
-  </a>
-  <a class="card" href="guides/steam-windows-client-apple-silicon.html">
-    <h3>Windows Steam client on M-series Macs</h3>
-    <p>Get the Steam client and D3D11 games rendering with wine-stable + DXMT.</p>
-  </a>
-  <a class="card" href="guides/whisky-alternative.html">
-    <h3>Whisky was discontinued: what now?</h3>
-    <p>An honest comparison of the free and paid options left in 2026.</p>
-  </a>
-  <a class="card" href="guides/ko/diablo-2-mac.html">
-    <h3>맥에서 디아블로 II 레저렉션 (한국어)</h3>
-    <p>애플 실리콘 맥에서 무료로 디아2를 돌리는 방법.</p>
-  </a>
+<section id="launchers" aria-labelledby="launchers-title">
+<h2 id="launchers-title">One toolkit. Four Windows launchers.</h2>
+<div class="platforms">
+<article class="platform"><h3>Battle.net</h3><p>Sign in, manage downloads and launch supported Blizzard games.</p><code>soju battlenet</code></article>
+<article class="platform"><h3>Steam</h3><p>Run the Windows client in its own Wine environment. D3D11 games need additional DXMT setup.</p><code>soju steam</code></article>
+<article class="platform"><h3>Epic Games Launcher</h3><p>Sign in, install games and return to the launcher from its tray.</p><code>soju epic</code></article>
+<article class="platform"><h3>GOG GALAXY</h3><p>Access your account and library. Game compatibility is still being explored.</p><code>soju gog</code></article>
 </div>
+<p class="note">Soju provides setup tools and launcher-specific Mac apps.
+You use each store's own interface and library.</p>
+</section>
 
-<h2>What actually works</h2>
-<p>Everything below was verified end-to-end on an M4 Pro running macOS 26:</p>
+<section id="install" aria-labelledby="install-title">
+<h2 id="install-title">Choose your launchers. Get set up.</h2>
+<p>The installer offers any combination of the four launchers and creates
+their shortcuts in <code>~/Applications</code>.</p>
+<pre><code>curl -fsSL https://soju.snack-wrap.com/install.sh | bash</code></pre>
+<p>Or install the CLI through Homebrew:</p>
+<pre><code>brew install BCD1210/soju/soju
+soju install</code></pre>
+<p>Use <code>soju doctor</code> to check your setup and <code>soju update</code>
+to update it. Homebrew-managed scripts update through <code>brew upgrade soju</code>.</p>
+<p class="note"><strong>Before you begin:</strong> Apple Silicon, Rosetta 2,
+Xcode Command Line Tools and Homebrew. The Battle.net, Epic and GOG setup uses
+Apple's Game Porting Toolkit, downloaded separately with an Apple ID.
+The tools are free; games and store accounts are your own.</p>
+</section>
+
+<section id="compatibility" aria-labelledby="compatibility-title">
+<h2 id="compatibility-title">Tested examples, clear limits.</h2>
+<p>These examples show what the toolkit can do. Compatibility depends on the game,
+store and system; launcher support does not mean every game will run.</p>
+<div class="table-scroll" role="region" aria-label="Tested game examples" tabindex="0">
 <table>
-  <tr><th>Target</th><th>Status</th></tr>
-  <tr><td>Battle.net (install, login, game management)</td><td>works</td></tr>
-  <tr><td>Diablo II: Resurrected (online, in-game)</td><td>works</td></tr>
-  <tr><td>Windows Steam client (login, library)</td><td>works</td></tr>
-  <tr><td>Steam D3D11 games (via DXMT)</td><td>works</td></tr>
-  <tr><td>Epic Games Launcher (login, game installs; Hogwarts Legacy in-game)</td><td>works</td></tr>
-  <tr><td>GOG GALAXY (login, library)</td><td>works</td></tr>
+<thead><tr><th scope="col">Example</th><th scope="col">Store</th><th scope="col">Evidence and conditions</th></tr></thead>
+<tbody>
+<tr><td>Hogwarts Legacy</td><td>Epic</td><td>Installed and played in-game using D3DMetal. Tested on M4 Pro / macOS 26.5.</td></tr>
+<tr><td>Diablo II: Resurrected</td><td>Battle.net</td><td>In-game and online on M4 Pro / macOS 26.5. Requires macOS 26.4 or later.
+<a href="https://github.com/BCD1210/soju/discussions/21">External user confirmation</a> also documents an Update/Play workaround.</td></tr>
+<tr><td>Unity D3D11 title</td><td>Steam</td><td>In-game on M4 Pro / macOS 26.5 with a custom DXMT setup. Additional build artifacts required.</td></tr>
+<tr><td>GOG GALAXY library</td><td>GOG</td><td>Login and library verified; games have not been broadly tested.</td></tr>
+</tbody>
 </table>
+</div>
+<p>Steam-edition D2R remains unverified. Games requiring unsupported kernel
+anti-cheat are outside the supported scope. Check the
+<a href="https://github.com/BCD1210/soju#what-runs">compatibility notes</a>
+before installing a game.</p>
+<p>Trying a different game or Mac? <a href="https://github.com/BCD1210/soju/discussions">Share a compatibility report</a>
+with the game, store, Mac model, macOS version and what worked.</p>
+</section>
 
-<h2>How it's free</h2>
-<p>The Wine engine is built from
-<a href="https://www.codeweavers.com/crossover/source">CodeWeavers' published GPL sources</a>
-(the same code CrossOver ships), graphics come from Apple's free
-<a href="https://developer.apple.com/games/game-porting-toolkit/">Game Porting Toolkit</a>,
-and Steam rendering uses <a href="https://github.com/3Shain/dxmt">DXMT</a> (LGPL).
-Nothing proprietary is redistributed. The one Apple file you need is downloaded
-from Apple directly, once.</p>
+<section id="guides" aria-labelledby="guides-title">
+<h2 id="guides-title">Start with your launcher or game.</h2>
+<div class="cards">
+<a class="card" href="https://github.com/BCD1210/soju#install-one-line"><h3>Setup and everyday commands</h3><p>Choose launchers, check your installation and update Soju.</p></a>
+<a class="card" href="guides/steam-windows-client-apple-silicon.html"><h3>Windows Steam on Apple Silicon</h3><p>Client setup, the DXMT game-rendering path and its requirements.</p></a>
+<a class="card" href="guides/diablo-2-resurrected-apple-silicon.html"><h3>Diablo II: Resurrected</h3><p>A worked example for Battle.net, including launch troubleshooting.</p></a>
+<a class="card" href="guides/ko/diablo-2-mac.html"><h3>맥에서 디아2 실행하기</h3><p>Battle.net 설치와 게임 실행 문제를 다루는 한국어 가이드.</p></a>
+<a class="card" href="guides/whisky-alternative.html"><h3>Mac gaming alternatives</h3><p>Where Soju fits alongside other Wine-based tools.</p></a>
+<a class="card" href="https://github.com/BCD1210/soju/blob/main/README.ko.md"><h3>Soju 한국어 소개</h3><p>네 가지 런처의 설치 방법과 현재 지원 범위.</p></a>
+</div>
+</section>
 
-<h2>Not just scripts: root causes</h2>
-<p>Every fix in Soju is documented with its underlying cause, so other Wine
-projects can reuse them: the <code>ROSETTA_ADVERTISE_AVX</code> discovery behind the
-famous D2R launch hang, Battle.net Agent's process-signature verification, and the
-Steam-client-vs-DXMT conflict. Start with the
-<a href="https://github.com/BCD1210/soju/blob/main/docs/STEAM-GAMES.md">Steam writeup</a>
-and the <a href="https://github.com/BCD1210/soju/blob/main/docs/DIAGNOSIS.md">Battle.net diagnosis</a>.</p>
+<section aria-labelledby="open-title">
+<h2 id="open-title">Open source, from setup to fixes.</h2>
+<p>Soju's scripts and documentation are open source. Its Wine engine is built from
+<a href="https://www.codeweavers.com/crossover/source">CodeWeavers' published sources</a>.
+Battle.net, Epic and GOG share that engine; Steam uses a separate
+<code>wine-stable</code> setup with DXMT for supported D3D11 games.</p>
+<p>Apple's proprietary D3DMetal/GPTK components are a separate download, and the
+store clients remain their publishers' software. Soju does not bundle them.</p>
+<p>The <a href="https://github.com/BCD1210/soju/blob/main/docs/DIAGNOSIS.md">diagnosis notes</a>
+and <a href="https://github.com/BCD1210/soju/blob/main/docs/STEAM-GAMES.md">Steam implementation notes</a>
+explain the fixes so others can inspect and reuse the work.</p>
+</section>
 </main>
-<footer>
-  Soju is GPL-3.0 · <a href="https://github.com/BCD1210/soju">github.com/BCD1210/soju</a> ·
-  not affiliated with Blizzard, Valve, Apple or CodeWeavers.
-</footer>
+<footer>Soju · <a href="https://github.com/BCD1210/soju">Source on GitHub</a> ·
+<a href="https://github.com/BCD1210/soju/releases">Releases</a><br>
+An independent project, not affiliated with Blizzard, Valve, Epic, GOG, Apple or CodeWeavers.</footer>
 </body>
 </html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -54,3 +54,18 @@ footer {
 .card:hover { border-color: var(--accent); }
 .card h3 { margin: 0 0 6px; font-size: 17px; }
 .card p { margin: 0; color: var(--dim); font-size: 14.5px; }
+
+/* Launcher overview, using the existing Soju palette. */
+html { scroll-padding-top: 1rem; }
+.hero { padding: 1.25rem 0 0.75rem; }
+.eyebrow { color: var(--accent); font-size: 0.875rem; font-weight: 700; letter-spacing: 0.06em; }
+.hero h1 { font-size: clamp(2rem, 6vw, 3.25rem); letter-spacing: -0.025em; }
+.actions { display: flex; align-items: center; flex-wrap: wrap; gap: 1.25rem; margin: 1.5rem 0; }
+.platforms { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 1rem; margin-top: 1rem; }
+.platform { background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: 1.1rem; }
+.platform h3 { margin: 0 0 0.5rem; }
+.platform p { margin: 0 0 1rem; font-size: 1rem; }
+.platform code { display: inline-block; }
+.table-scroll { overflow-x: auto; }
+a:focus-visible, [tabindex]:focus-visible { outline: 2px solid var(--link); outline-offset: 4px; }
+@media (max-width: 540px) { .platforms { grid-template-columns: 1fr; } }

--- a/marketing/launch-kit.md
+++ b/marketing/launch-kit.md
@@ -1,0 +1,65 @@
+# Soju launch kit
+
+Drafts for manual publication. Positioning: a free, open-source game launcher toolkit for Apple Silicon Macs.
+
+Soju sets up Battle.net, Steam, Epic Games Launcher and GOG GALAXY. It provides terminal setup, separate Wine environments and a Mac launch app for each store. The store clients retain their own interfaces; a unified library UI is not currently provided.
+
+## English community post
+
+Title: Soju: an open-source toolkit for Windows game launchers on Apple Silicon
+
+I'm building Soju, a free, open-source toolkit that sets up Battle.net, Windows Steam, Epic Games Launcher and GOG GALAXY on Apple Silicon Macs.
+
+Choose the launchers you use, install them in separate Wine environments, and open them through Mac launch shortcuts. You sign in with your existing store accounts.
+
+Current verified examples on M4 Pro / macOS 26.5 include Hogwarts Legacy through Epic, Diablo II: Resurrected through Battle.net, and a Unity D3D11 title through Steam with a custom DXMT setup. GOG login and library access are verified; its games have not been broadly tested.
+
+Steam game rendering needs additional setup. D2R needs macOS 26.4 or later, and Apple's GPTK components for the Battle.net/Epic/GOG path are downloaded separately. Launcher support does not imply that every game works.
+
+I'm looking for compatibility reports across different games and Macs: game + store, Mac model, macOS version, Soju/engine version, and what worked or failed. Reproducible bug reports and contributions are welcome.
+
+Project and installation: https://soju.snack-wrap.com/
+Source: https://github.com/BCD1210/soju
+Reports: https://github.com/BCD1210/soju/discussions
+
+## Short post
+
+Soju is a free, open-source launcher toolkit for Apple Silicon Macs: Battle.net, Steam, Epic and GOG, with separate Wine environments and Mac launch shortcuts. Compatibility varies by game. Try it and share what works: https://soju.snack-wrap.com/
+
+## 한국어 커뮤니티 글
+
+제목: Apple Silicon 맥용 오픈소스 게임 런처 도구 Soju를 만들고 있습니다
+
+Soju는 맥에서 Battle.net, Windows Steam, Epic Games Launcher, GOG GALAXY를 설치하고 실행하도록 돕는 무료 오픈소스 프로젝트입니다.
+
+터미널에서 사용할 런처를 선택하면 각각 분리된 Wine 환경에 설치하고, 맥에서 실행할 수 있는 바로가기를 만듭니다. 로그인과 라이브러리는 각 스토어의 기존 화면을 사용합니다.
+
+현재 M4 Pro / macOS 26.5에서 Epic의 호그와트 레거시, Battle.net의 디아블로 2: 레저렉션, 별도 DXMT 설정을 사용한 Steam의 Unity D3D11 게임 실행을 확인했습니다. GOG는 로그인과 라이브러리까지 확인했으며 게임 호환성은 추가 검증이 필요합니다.
+
+Steam 게임 실행에는 추가 설정이 필요하고, 디아2는 macOS 26.4 이상이 필요합니다. Battle.net·Epic·GOG 경로에서 사용하는 Apple GPTK 구성요소는 별도로 내려받습니다. 모든 게임의 실행을 보장하는 단계는 아닙니다.
+
+다양한 게임과 맥에서 결과를 모으고 있습니다. 게임명·스토어·맥 모델·macOS 버전·Soju/엔진 버전과 함께 성공 사례나 재현 가능한 오류를 알려주시면 도움이 됩니다.
+
+소개와 설치: https://soju.snack-wrap.com/
+소스: https://github.com/BCD1210/soju
+실행 결과: https://github.com/BCD1210/soju/discussions
+
+## Demo recording plan
+
+Capture the real installed software; this is a storyboard, not a finished recording.
+
+- 0–5 seconds: title, “Your Windows launchers. On your Mac.”
+- 5–15 seconds: show the launcher choices and installed Mac shortcuts.
+- 15–30 seconds: show available launcher windows and libraries, with private account details hidden.
+- 30–40 seconds: show actual gameplay from verified examples and label game, store, Mac and macOS version.
+- 40–45 seconds: project URL and request for compatibility reports.
+
+Include Steam's extra DXMT setup and GOG's limited verification in the accompanying text. Never label a launcher library screen as verified gameplay.
+
+## Publication notes
+
+- Check the destination's current self-promotion rules before posting.
+- Use an existing project thread for a substantive update when appropriate; avoid duplicate launch posts.
+- Keep D2R-specific guides discoverable while the main project introduction covers all four launchers.
+- Link to compatibility notes and ask for evidence, not only stars.
+- Record the post URL and date after publishing. These drafts have not been submitted to communities.


### PR DESCRIPTION
## Why
Introduce Soju as an open-source launcher toolkit across Battle.net, Steam, Epic and GOG so visitors understand its broader scope.

## Changes
- Rework the homepage around four launchers, installation and documented compatibility.
- Align English, Korean and Chinese README introductions and social metadata.
- Preserve game-specific guides and link them back to the project overview.
- Add English/Korean community drafts, a short post and a real-footage demo storyboard. No community posts have been submitted.

## Validation
Checked local links and anchors across all five HTML pages, README target headings and git diff whitespace. Existing technical compatibility notes inform the copy; Steam extra setup and GOG verification limits remain explicit. Runtime scripts are unchanged.
