### PR TITLE
fix(uninstall): wait for wineserver to exit before deleting a bottle

### DIFF
--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -24,6 +24,9 @@ stop_bottle() {
   [ "$b" != steam-bottle ] || ws="/Applications/Wine Stable.app/Contents/Resources/wine/bin/wineserver"
   [ -d "$BASE/$b" ] || return 0
   WINEPREFIX="$BASE/$b" DYLD_FALLBACK_LIBRARY_PATH="$ENGINE/lib:/usr/lib" "$ws" -k 2>/dev/null || true
+  # -k only asks; wait for the server to be gone before rm -rf, otherwise
+  # shutdown-time writes race the delete and can leave half a bottle behind.
+  WINEPREFIX="$BASE/$b" DYLD_FALLBACK_LIBRARY_PATH="$ENGINE/lib:/usr/lib" "$ws" -w 2>/dev/null || true
 }
 
 # 2. App bundles.


### PR DESCRIPTION
Follow-up to #26, the Codex P2 that was still open when it merged. `wineserver -k` only asks the server to shut down and returns at once, so the `rm -rf` that follows raced the shutdown-time writes and could leave a partially deleted bottle (or abort the rest of the uninstall under `set -e`). Now `stop_bottle` waits with `wineserver -w` before returning. No wait when no server is running: `-w` returns immediately then.